### PR TITLE
Update to marked 0.3.9 after github warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,7 +1609,7 @@
         "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.6",
+        "marked": "0.3.9",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "requizzle": "0.2.1",
         "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",


### PR DESCRIPTION
This updates the marked dependency in JS Docs which is currently set @ ~0.3.6 in our package-lock.json.

I was able to run the build command and give the ~ this should be fine.