### PR TITLE
RUN-3949 Fixed issue where no correlation errors were thrown when use d along side the legacy API.

### DIFF
--- a/src/transport/transport-errors.ts
+++ b/src/transport/transport-errors.ts
@@ -14,8 +14,6 @@ export class DuplicateCorrelationError extends Error { }
 
 export class NoAckError extends Error { }
 
-export class NoCorrelationError extends Error { }
-
 export class NotImplementedError extends Error { }
 
 export class RuntimeError extends Error {

--- a/src/transport/transport.ts
+++ b/src/transport/transport.ts
@@ -15,7 +15,6 @@ import {
     UnexpectedActionError,
     DuplicateCorrelationError,
     NoAckError,
-    NoCorrelationError,
     RuntimeError
 } from './transport-errors';
 
@@ -165,8 +164,7 @@ class Transport extends EventEmitter {
             // tslint:disable-next-line
             this.uncorrelatedListener = () => { };
         } else if (!(id in this.wireListeners)) {
-            throw new NoCorrelationError(String(id));
-            // Return false?
+            return false;
         } else {
             const { resolve, reject } = this.wireListeners[id];
             if (data.action !== 'ack') {


### PR DESCRIPTION
NoCorrelation Errors should not exist.