### PR TITLE
RUN-3999 multi runtime tests config update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hadouken-js-adapter",
-  "version": "0.2.2",
+  "version": "0.30.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hadouken-js-adapter",
-    "version": "0.30.1",
+    "version": "0.30.2",
     "license": "Apache-2.0",
     "repository": "https://github.com/HadoukenIO/js-adapter",
     "main": "./out/src/main.js",

--- a/src/api/plugin/plugin.ts
+++ b/src/api/plugin/plugin.ts
@@ -12,7 +12,6 @@ export interface PluginBare {
  * @namespace
 */
 export default class Plugin extends Base {
-    private idBase: string;
     private pluginsImportBaseKey: string; // unique plugins key for window
     private noEsmSupportErrorMsg: string;
     private importId: number;
@@ -21,8 +20,7 @@ export default class Plugin extends Base {
         super(wire);
 
         this.importId = 0;
-        this.idBase = wire.environment.getRandomId();
-        this.pluginsImportBaseKey = `__plugins_${this.idBase}_import_`;
+        this.pluginsImportBaseKey = '__plugins_import_';
         this.noEsmSupportErrorMsg = 'ES modules are not supported in this version of OpenFin.';
     }
 

--- a/test/multi-runtime-utils.ts
+++ b/test/multi-runtime-utils.ts
@@ -125,7 +125,8 @@ function generateAppConfig(): any {
             name: uuid,
             autoShow: true,
             url: appConfig.startup_app.url,
-            saveWindowState: false
+            saveWindowState: false,
+            experimental: appConfig.startup_app.experimental
         }
     };
 }


### PR DESCRIPTION
This PR is to update the config that multi runtime tests use.  Currently we enable v2api by default, but the config that these tests use is not updated. 