### PR TITLE
RUN-4033 plugin.import accepts a string

### DIFF
--- a/src/api/plugin/plugin.ts
+++ b/src/api/plugin/plugin.ts
@@ -2,11 +2,6 @@ import { Base } from '../base';
 import Transport from '../../transport/transport';
 import { notImplementedEnvErrorMsg } from '../../environment/environment';
 
-export interface PluginBare {
-    name: string;
-    version: string;
-}
-
 /**
  * The Plugin API allows importing OpenFin plugins
  * @namespace
@@ -32,13 +27,11 @@ export default class Plugin extends Base {
      * **Important**: If you set HTTP Content-Security-Policy's `script-src` directive
      * you must allow `unsafe-inline` for `blob:` for this API to work.
      *
-     * @param {Object} plugin - Plugin to import. Specified plugin must be listed in app's manifest.
-     * @param {string} plugin.name - plugin name
-     * @param {string} plugin.version - plugin version
+     * @param {string} name - Plugin to import. Specified plugin must be listed in app's manifest.
      * @return {Promise<any>}
      * @tutorial Plugin.import
      */
-    public async import(plugin: PluginBare): Promise<any> {
+    public async import(name: string): Promise<any> {
         if (!this.isOpenFinEnvironment()) {
             throw new Error(notImplementedEnvErrorMsg);
         }
@@ -47,10 +40,10 @@ export default class Plugin extends Base {
             throw new Error(this.noEsmSupportErrorMsg);
         }
 
-        const { payload } = await this.wire.sendAction('get-plugin-module', { plugin });
-        const { data: { _content } } = payload;
+        const { payload } = await this.wire.sendAction('get-plugin-module', name);
+        const { data: content } = payload;
 
-        return this.importModule(_content);
+        return this.importModule(content);
     }
 
     // ESM is supported in OF v9+

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -3,10 +3,6 @@ import { Fin } from '../src/main';
 
 describe('Plugin.', () => {
     let fin: Fin;
-    const plugin = {
-        name: 'plugin_1',
-        version: '0.0.1'
-    };
 
     before(() => {
         return conn().then((res) => fin = res);
@@ -16,7 +12,7 @@ describe('Plugin.', () => {
 
         it('Doesn\'t work in Node environment', async () => {
             try {
-                await fin.Plugin.import(plugin);
+                await fin.Plugin.import('plugin_1');
             } catch (error) {
                 return true;
             }

--- a/tutorials/Plugin.import.md
+++ b/tutorials/Plugin.import.md
@@ -1,16 +1,11 @@
-Imports an OpenFin plugin. Plugins can be written using ES modules, and the API object that 
+Imports an OpenFin plugin. Plugins can be written using ES modules, and the API object that
 is resolved in the promise contains the exported API of the plugin.
 
 ### Example
 
 ```js
 // This plugin must be listed in root application's manifest
-const plugin = {
-    name: 'foo',
-    version: '0.0.1'
-};
-
-fin.desktop.Plugin.import(plugin)
+fin.desktop.Plugin.import('foo')
     .then((api) => {
         api.bar();
     })


### PR DESCRIPTION
ℹ️ PR's changes: fin.Plugin.import accepts a string instead of an object

**Chained with these PRs:**
⛓ [core PR](https://github.com/HadoukenIO/core/pull/396)
⛓ [javascript-adapter PR](https://github.com/openfin/javascript-adapter/pull/425)