### PR TITLE
Feature/test sledghammer

### DIFF
--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -14,7 +14,7 @@ describe('Application.', function() {
     let counter = 0;
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
 
     beforeEach(async () => {

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -1,5 +1,6 @@
 import { conn } from './connect';
 import { Fin, Application, connect as rawConnect } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 import * as assert from 'assert';
 import * as path from 'path';
 
@@ -11,10 +12,12 @@ describe('Application.', function() {
     this.timeout(30000);
 
     let counter = 0;
-    before(() => conn().then((a: Fin) => {
-
-        fin = a;
-    }));
+    before(async () => {
+        await conn().then((a: Fin) => {
+            fin = a;
+        });
+        await cleanOpenRuntimes();
+    });
 
     beforeEach(async () => {
         testApp = await fin.Application.create({

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -13,10 +13,8 @@ describe('Application.', function() {
 
     let counter = 0;
     before(async () => {
-        await conn().then((a: Fin) => {
-            fin = a;
-        });
         await cleanOpenRuntimes();
+        return fin = await conn();
     });
 
     beforeEach(async () => {

--- a/test/clipboard.test.ts
+++ b/test/clipboard.test.ts
@@ -20,7 +20,7 @@ describe('Clipboard.', () => {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
 
     describe('writeText()', () => {

--- a/test/clipboard.test.ts
+++ b/test/clipboard.test.ts
@@ -1,6 +1,7 @@
 import { conn } from './connect';
 import * as assert from 'assert';
 import { Fin } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 describe('Clipboard.', () => {
     let fin: Fin;
@@ -17,8 +18,9 @@ describe('Clipboard.', () => {
         }
     };
 
-    before(() => {
-        return conn().then((a: Fin) => fin = a);
+    before(async () => {
+        await cleanOpenRuntimes();
+        return await conn().then((a: Fin) => fin = a);
     });
 
     describe('writeText()', () => {

--- a/test/clipboard.test.ts
+++ b/test/clipboard.test.ts
@@ -20,7 +20,7 @@ describe('Clipboard.', () => {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return await conn().then((a: Fin) => fin = a);
+        return fin = await conn();
     });
 
     describe('writeText()', () => {

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -7,7 +7,7 @@ describe('connect()', () => {
     let fin: Fin;
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
     it('authentication', () => {
         assert(fin.System !== undefined);

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,11 +1,13 @@
 import { conn } from './connect';
 import * as assert from 'assert';
 import { connect as rawConnect, Fin } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 describe('connect()', () => {
     let fin: Fin;
-    before(() => {
-        return conn().then((a: Fin) => fin = a);
+    before(async () => {
+        await cleanOpenRuntimes();
+        return fin = await conn();
     });
     it('authentication', () => {
         assert(fin.System !== undefined);

--- a/test/connect.ts
+++ b/test/connect.ts
@@ -1,5 +1,4 @@
 import { connect, Fin } from '../src/main';
-import { kill } from './multi-runtime-utils';
 
 const MAX_TRY_NUMBER = 5;
 let c: Promise<Fin>;
@@ -23,12 +22,4 @@ export function conn() {
     }
 
     return c;
-}
-
-export async function clean() {
-    if (c) {
-        const f = await c;
-        kill(f);
-        c = null;
-    }
 }

--- a/test/event-emitter.test.ts
+++ b/test/event-emitter.test.ts
@@ -21,7 +21,7 @@ describe ('Event Emitter Methods', () => {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
 
     beforeEach(async () => {

--- a/test/event-emitter.test.ts
+++ b/test/event-emitter.test.ts
@@ -19,11 +19,9 @@ describe ('Event Emitter Methods', () => {
         }
     };
 
-    before(() => {
-        return conn().then(async a => {
-            fin = a;
-            await cleanOpenRuntimes();
-        });
+    before(async () => {
+        await cleanOpenRuntimes();
+        return fin = await conn();
     });
 
     beforeEach(async () => {

--- a/test/external-application.test.ts
+++ b/test/external-application.test.ts
@@ -7,7 +7,7 @@ describe('ExternalApplication.', () => {
     let fin: Fin;
     before(async () => {
         await cleanOpenRuntimes();
-        return await conn().then((a: Fin) => fin = a);
+        return fin = await conn();
     });
 
     describe('getInfo()', () => {

--- a/test/external-application.test.ts
+++ b/test/external-application.test.ts
@@ -7,7 +7,7 @@ describe('ExternalApplication.', () => {
     let fin: Fin;
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
 
     describe('getInfo()', () => {

--- a/test/external-application.test.ts
+++ b/test/external-application.test.ts
@@ -1,10 +1,14 @@
 import { conn } from './connect';
 import { Fin } from '../src/main';
 import * as assert from 'assert';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 describe('ExternalApplication.', () => {
     let fin: Fin;
-    before(() => conn().then((a: Fin) => fin = a));
+    before(async () => {
+        await cleanOpenRuntimes();
+        return await conn().then((a: Fin) => fin = a);
+    });
 
     describe('getInfo()', () => {
         it('Fulfilled', () => fin.System.getAllExternalApplications().

--- a/test/frame.test.ts
+++ b/test/frame.test.ts
@@ -9,7 +9,7 @@ describe('Frame.', () => {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
 
     beforeEach(() => {

--- a/test/frame.test.ts
+++ b/test/frame.test.ts
@@ -1,13 +1,15 @@
 import { conn } from './connect';
 import * as assert from 'assert';
 import { Fin, Frame } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 describe('Frame.', () => {
     let fin: Fin;
     let testFrame: Frame;
 
-    before(() => {
-        return conn().then(a => fin = a);
+    before(async () => {
+        await cleanOpenRuntimes();
+        return await conn().then((a: Fin) => fin = a);
     });
 
     beforeEach(() => {

--- a/test/frame.test.ts
+++ b/test/frame.test.ts
@@ -9,7 +9,7 @@ describe('Frame.', () => {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return await conn().then((a: Fin) => fin = a);
+        return fin = await conn();
     });
 
     beforeEach(() => {

--- a/test/interappbus.test.ts
+++ b/test/interappbus.test.ts
@@ -1,6 +1,7 @@
 import { conn } from './connect';
 import * as assert from 'assert';
 import { connect as rawConnect, Fin } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 const id = 'adapter-test-window';
 const topic = 'topic';
@@ -14,6 +15,10 @@ function noop() { }
 
 describe('InterApplicationBus.', () => {
     let fin: Fin;
+
+    before(async () => {
+        await cleanOpenRuntimes();
+    });
 
     beforeEach(() => {
         return conn().then((a: Fin) => fin = a);

--- a/test/interappbus.test.ts
+++ b/test/interappbus.test.ts
@@ -20,8 +20,8 @@ describe('InterApplicationBus.', () => {
         await cleanOpenRuntimes();
     });
 
-    beforeEach(() => {
-        return conn().then((a: Fin) => fin = a);
+    beforeEach(async () => {
+        fin = await conn();
     });
 
     it('subscribe()', (done) => {

--- a/test/multi-runtime-application.test.ts
+++ b/test/multi-runtime-application.test.ts
@@ -1,15 +1,16 @@
+/* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code */
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
-import { cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT, launchX } from './multi-runtime-utils';
-import { clean } from './connect';
+import { cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT, launchAndConnect } from './multi-runtime-utils';
 
-describe('Multi Runtime', () => {
+describe('Multi Runtime', function () {
     let appConfigTemplate: any;
-    before(() => {
-        clean();
-    });
 
-    describe('Application', () => {
+    describe('Application', function () {
+
+        this.retries(2);
+        this.slow(TEST_TIMEOUT / 2 );
+        this.timeout(TEST_TIMEOUT);
 
         function getAppConfig(): any {
             const appConfigTemplate = {
@@ -22,27 +23,22 @@ describe('Multi Runtime', () => {
                 }
             };
 
-            // tslint:disable-next-line
             appConfigTemplate.uuid += Math.floor(Math.random() * 10000);
             return appConfigTemplate;
         }
 
-        beforeEach(() => {
+        beforeEach(async function () {
             appConfigTemplate = getAppConfig();
-        });
-
-        afterEach(async () => {
             return await cleanOpenRuntimes();
         });
 
-        describe('getInfo', () => {
+        describe('getInfo', function () {
+
             it('should return the application Information', async function () {
-                // tslint:disable-next-line no-invalid-this
-                this.timeout(TEST_TIMEOUT);
                 const expectedLaunchMode = 'adapter';
-                const conns = await launchX(2);
-                const finA = conns[0];
-                const finB = conns[1];
+                const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
+                await delayPromise(DELAY_MS);
+
                 const realApp = await finB.Application.create(appConfigTemplate);
                 await realApp.run();
                 const app = await finA.Application.wrap({ uuid: appConfigTemplate.uuid });
@@ -52,13 +48,10 @@ describe('Multi Runtime', () => {
             });
         });
 
-        describe('getParentUuid', () => {
+        describe('getParentUuid', function () {
+
             it('should return the uuid of the parent adapter connection', async function () {
-                // tslint:disable-next-line no-invalid-this
-                this.timeout(TEST_TIMEOUT);
-                const conns = await launchX(2);
-                const finA = conns[0];
-                const finB = conns[1];
+                const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 const expectedUuid = finB.wire.me.uuid;
 
                 await delayPromise(DELAY_MS);
@@ -72,13 +65,10 @@ describe('Multi Runtime', () => {
             });
         });
 
-        describe('isRunning', () => {
+        describe('isRunning', function () {
+
             it('should return the running state of an application', async function () {
-                // tslint:disable-next-line no-invalid-this
-                this.timeout(TEST_TIMEOUT);
-                const conns = await launchX(2);
-                const finA = conns[0];
-                const finB = conns[1];
+                const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
 
                 await delayPromise(DELAY_MS);
                 const realApp = await finB.Application.create(appConfigTemplate);

--- a/test/multi-runtime-application.test.ts
+++ b/test/multi-runtime-application.test.ts
@@ -1,10 +1,13 @@
 /* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code */
+import { conn } from './connect';
+import { Fin } from '../src/main';
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
 import { cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT, launchAndConnect } from './multi-runtime-utils';
 
 describe('Multi Runtime', function () {
     let appConfigTemplate: any;
+    let fin: Fin;
 
     describe('Application', function () {
 
@@ -26,6 +29,12 @@ describe('Multi Runtime', function () {
             appConfigTemplate.uuid += Math.floor(Math.random() * 10000);
             return appConfigTemplate;
         }
+
+        before(async () => {
+            await conn().then((a: Fin) => {
+                fin = a;
+            });
+        });
 
         beforeEach(async function () {
             appConfigTemplate = getAppConfig();

--- a/test/multi-runtime-application.test.ts
+++ b/test/multi-runtime-application.test.ts
@@ -31,9 +31,7 @@ describe('Multi Runtime', function () {
         }
 
         before(async () => {
-            await conn().then((a: Fin) => {
-                fin = a;
-            });
+            fin = await conn();
         });
 
         beforeEach(async function () {

--- a/test/multi-runtime-events.test.ts
+++ b/test/multi-runtime-events.test.ts
@@ -1,8 +1,15 @@
+/* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code no-empty */
+import { conn } from './connect';
+import { Fin } from '../src/main';
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
-import { launchAndConnect, cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT, launchX } from './multi-runtime-utils';
+import { launchAndConnect, cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT } from './multi-runtime-utils';
 
-describe('Multi Runtime', () => {
+describe('Multi Runtime', function() {
+    let fin: Fin;
+
+    this.slow(TEST_TIMEOUT / 2 );
+    this.timeout(TEST_TIMEOUT * 2);
 
     function getAppConfig() {
         const appConfigTemplate = {
@@ -13,58 +20,57 @@ describe('Multi Runtime', () => {
             saveWindowState: false,
             accelerator: {
                 devtools: true
+            },
+            experimental: {
+                v2api: true
             }
         };
 
-        // tslint:disable-next-line
         appConfigTemplate.uuid += Math.floor(Math.random() * 1000);
         return appConfigTemplate;
     }
 
-    afterEach(async () => {
+    before(async () => {
+        await conn().then((a: Fin) => {
+            fin = a;
+        });
+    });
+
+    beforeEach(async function() {
         return await cleanOpenRuntimes();
     });
 
-    describe('Events', () => {
+    describe('Events', function() {
 
-        describe('Launch then subscribe', () => {
-            describe('System', () => {
-                // tslint:disable-next-line
-                it('should raise application closed events', function (done: Function) {
-                    // tslint:disable-next-line no-invalid-this
-                    this.timeout(TEST_TIMEOUT * 2);
+        describe('Launch then subscribe', function() {
+            describe('System', function() {
+                it('should raise application started events', function (done: Function) {
 
                     async function test() {
                         const appConfig = getAppConfig();
-                        const conns = await launchX(2);
-                        const finA = conns[0];
-                        const finB = conns[1];
+                        const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                         await delayPromise(DELAY_MS);
-
                         const realApp = await finB.Application.create(appConfig);
-                        await realApp.run();
+                        finA.System.on('application-started', async (e: any) => {
+                            assert.equal(e.type, 'application-started', 'Expected event type to match event');
+                            await realApp.close();
 
-                        finA.System.on('application-closed', (e: any) => {
-                            assert.equal(e.type, 'application-closed', 'Expected event type to match event');
                             done();
                         });
-
                         await delayPromise(DELAY_MS);
-                        await realApp.close();
-                        await delayPromise(1500);
+
+                        return await realApp.run();
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
 
                 it('should raise application created events', function (done: Function) {
-                    // tslint:disable-next-line no-invalid-this
-                    this.timeout(TEST_TIMEOUT * 2);
 
                     async function test() {
-                        const conns = await launchX(2);
-                        const finA = conns[0];
-                        const finB = conns[1];
+                        const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
+                        await delayPromise(DELAY_MS);
+
                         const appConfig = getAppConfig();
                         await delayPromise(DELAY_MS);
                         let realApp: any;
@@ -82,51 +88,42 @@ describe('Multi Runtime', () => {
                         await delayPromise(DELAY_MS);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
             });
         });
 
-        describe('Launch then subscribe', () => {
-            describe('application', () => {
-                // tslint:disable-next-line
-                it.skip('should raise closed events', function (done: Function) {
-                    // tslint:disable-next-line no-invalid-this
-                    this.timeout(TEST_TIMEOUT);
-
+        describe('Launch then subscribe', function() {
+            describe('Application', function() {
+                it('should raise application started events', function (done: Function) {
                     async function test() {
                         const appConfig = getAppConfig();
-                        const conns = await launchX(2);
-                        const finA = conns[0];
-                        const finB = conns[1];
+                        const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
+                        await delayPromise(DELAY_MS);
+                        const realApp = await finB.Application.create(appConfig);
+                        const app = await finA.Application.wrap({ uuid: appConfig.uuid });
                         await delayPromise(DELAY_MS);
 
-                        const realApp = await finB.Application.create(appConfig.uuid);
-                        await realApp.run();
-                        const app = await finA.Application.wrap({ uuid: appConfig.uuid });
+                        app.on('initialized', async (e: any) => {
+                            assert.equal(e.type, 'initialized', 'Expected event type to match event');
+                            await app.close();
 
-                        app.on('closed', (e: any) => {
-                            assert.equal(e.type, 'closed', 'Expected event type to match event');
                             done();
                         });
 
                         await delayPromise(DELAY_MS);
-                        await realApp.close();
-                        await delayPromise(DELAY_MS);
+                        await realApp.run();
                     }
 
-                    test();
+                    test().catch((err) => {
+                        cleanOpenRuntimes();
+                    });
                 });
 
                 it('should raise initialized events', function (done: () => void) {
-                    // tslint:disable-next-line no-invalid-this
-                    this.timeout(TEST_TIMEOUT);
-
                     async function test() {
-                        const conns = await launchX(2);
-                        const finA = conns[0];
-                        const finB = conns[1];
                         const appConfig = getAppConfig();
+                        const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                         await delayPromise(DELAY_MS);
 
                         const realApp = await finB.Application.create(appConfig);
@@ -143,24 +140,20 @@ describe('Multi Runtime', () => {
                         await delayPromise(DELAY_MS);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
             });
         });
 
-        describe('Launch then subscribe', () => {
-            describe('Window', () => {
+        describe('Launch then subscribe', function() {
+            describe('Window', function() {
 
                 it('should raise initialized', function (done: (value: void) => void) {
-                    // tslint:disable-next-line no-invalid-this
-                    this.timeout(TEST_TIMEOUT);
-
                     async function test() {
                         const appConfig = getAppConfig();
-                        const conns = await launchX(2);
-                        const finA = conns[0];
-                        const finB = conns[1];
+                        const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                         await delayPromise(DELAY_MS);
+
                         const app = await finA.Application.wrap({ uuid: appConfig.uuid });
                         const win = await app.getWindow();
 
@@ -175,26 +168,24 @@ describe('Multi Runtime', () => {
                         await delayPromise(DELAY_MS);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
             });
         });
 
-        describe('Subscribe then launch', () => {
+        describe('Subscribe then launch', function() {
 
-            describe('System', () => {
+            describe('System', function() {
 
-                // tslint:disable-next-line
                 it('should raise application closed events', function (done: Function) {
-                    // tslint:disable-next-line no-invalid-this
                     this.timeout(TEST_TIMEOUT * 2);
 
                     async function test() {
                         const appConfig = getAppConfig();
                         const finA = await launchAndConnect();
                         await delayPromise(DELAY_MS);
-                        finA.System.on('application-closed', (e: any) => {
-                            assert.equal(e.type, 'application-closed', 'Expected event type to match event');
+                        finA.System.on('application-started', (e: any) => {
+                            assert.equal(e.type, 'application-started', 'Expected event type to match event');
                             done();
                         });
                         const finB = await launchAndConnect();
@@ -207,22 +198,15 @@ describe('Multi Runtime', () => {
                         await delayPromise(1500);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
 
                 it('should raise application-started events', function (done: (value: void) => void) {
-                    // tslint:disable-next-line no-invalid-this
                     this.timeout(TEST_TIMEOUT * 2); //We need a bit more time for these tests.
 
                     async function test() {
                         const appConfig = getAppConfig();
-                        const argsConnect = [
-                            '--security-realm=supersecret',
-                            '--enable-mesh',
-                            '--enable-multi-runtime',
-                            '--v=1'
-                        ];
-                        const finA = await launchAndConnect(undefined, undefined, 'supersecret', argsConnect);
+                        const finA = await launchAndConnect();
                         await delayPromise(DELAY_MS);
 
                         const app = await finA.Application.wrap({ uuid: appConfig.uuid });
@@ -242,20 +226,18 @@ describe('Multi Runtime', () => {
                         await delayPromise(DELAY_MS);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
             });
 
         });
 
-        describe('Subscribe then launch', () => {
+        describe('Subscribe then launch', function() {
 
-            describe('Application', () => {
+            describe('Application', function() {
 
                 //Bug regarding Application/Window close events.
-                // tslint:disable-next-line
                 it.skip('should raise closed events', function (done: Function) {
-                    // tslint:disable-next-line no-invalid-this
                     this.timeout(TEST_TIMEOUT * 2);
 
                     async function test() {
@@ -277,21 +259,15 @@ describe('Multi Runtime', () => {
                         await delayPromise(DELAY_MS);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
 
-                it('should raise initialized events', function (done: (value: void) => void) {
-                    // tslint:disable-next-line no-invalid-this
+                it('should raise initialized eventsss', function (done: (value: void) => void) {
                     this.timeout(TEST_TIMEOUT * 2); //We need a bit more time for these tests.
 
                     async function test() {
                         const appConfig = getAppConfig();
-                        const argsConnect = [
-                            '--enable-mesh',
-                            '--enable-multi-runtime',
-                            '--v=1'
-                        ];
-                        const finA = await launchAndConnect(undefined, undefined, 'supersecret', argsConnect);
+                        const finA = await launchAndConnect();
                         await delayPromise(DELAY_MS);
 
                         const app = await finA.Application.wrap({ uuid: appConfig.uuid });
@@ -311,17 +287,16 @@ describe('Multi Runtime', () => {
                         await delayPromise(DELAY_MS);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
             });
 
         });
 
-        describe('Subscribe then launch', () => {
-            describe('Window', () => {
+        describe('Subscribe then launch', function() {
+            describe('Window', function() {
 
                 it('should raise bounds-changed', function (done: (value: void) => void) {
-                    // tslint:disable-next-line no-invalid-this
                     this.timeout(TEST_TIMEOUT * 2); //We need a bit more time for these tests.
 
                     async function test() {
@@ -346,11 +321,10 @@ describe('Multi Runtime', () => {
                         await delayPromise(DELAY_MS);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
 
                 it('should raise hidden', function (done: (value: void) => void) {
-                    // tslint:disable-next-line no-invalid-this
                     this.timeout(TEST_TIMEOUT * 2); //We need a bit more time for these tests.
 
                     async function test() {
@@ -358,6 +332,8 @@ describe('Multi Runtime', () => {
                         const finA = await launchAndConnect();
                         const app = await finA.Application.wrap({ uuid: appConfig.uuid });
                         const win = await app.getWindow();
+
+                        await delayPromise(DELAY_MS);
 
                         win.on('hidden', (e: any) => {
                             assert.equal(e.type, 'hidden', 'Expected event type to match event');
@@ -373,7 +349,7 @@ describe('Multi Runtime', () => {
                         await delayPromise(DELAY_MS);
                     }
 
-                    test();
+                    test().catch(() => cleanOpenRuntimes());
                 });
 
             });

--- a/test/multi-runtime-events.test.ts
+++ b/test/multi-runtime-events.test.ts
@@ -31,9 +31,7 @@ describe('Multi Runtime', function() {
     }
 
     before(async () => {
-        await conn().then((a: Fin) => {
-            fin = a;
-        });
+        fin = await conn();
     });
 
     beforeEach(async function() {
@@ -104,8 +102,8 @@ describe('Multi Runtime', function() {
                         const app = await finA.Application.wrap({ uuid: appConfig.uuid });
                         await delayPromise(DELAY_MS);
 
-                        app.on('initialized', async (e: any) => {
-                            assert.equal(e.type, 'initialized', 'Expected event type to match event');
+                        app.on('started', async (e: any) => {
+                            assert.equal(e.type, 'started', 'Expected event type to match event');
                             await app.close();
 
                             done();
@@ -177,7 +175,7 @@ describe('Multi Runtime', function() {
 
             describe('System', function() {
 
-                it('should raise application closed events', function (done: Function) {
+                it('should raise application started events', function (done: Function) {
                     this.timeout(TEST_TIMEOUT * 2);
 
                     async function test() {
@@ -201,7 +199,7 @@ describe('Multi Runtime', function() {
                     test().catch(() => cleanOpenRuntimes());
                 });
 
-                it('should raise application-started events', function (done: (value: void) => void) {
+                it('should raise application-created events', function (done: (value: void) => void) {
                     this.timeout(TEST_TIMEOUT * 2); //We need a bit more time for these tests.
 
                     async function test() {
@@ -236,8 +234,7 @@ describe('Multi Runtime', function() {
 
             describe('Application', function() {
 
-                //Bug regarding Application/Window close events.
-                it.skip('should raise closed events', function (done: Function) {
+                it('should raise started events', function (done: Function) {
                     this.timeout(TEST_TIMEOUT * 2);
 
                     async function test() {
@@ -245,8 +242,9 @@ describe('Multi Runtime', function() {
                         const finA = await launchAndConnect();
                         await delayPromise(DELAY_MS);
                         const app = await finA.Application.wrap({ uuid: appConfig.uuid });
-                        app.on('closed', (e: any) => {
-                            assert.equal(e.type, 'closed', 'Expected event type to match event');
+                        app.on('started', async (e: any) => {
+                            assert.equal(e.type, 'started', 'Expected event type to match event');
+                            await app.close();
                             done();
                         });
                         const finB = await launchAndConnect();
@@ -254,8 +252,6 @@ describe('Multi Runtime', function() {
                         const realApp = await finB.Application.create(appConfig);
                         await realApp.run();
 
-                        await delayPromise(DELAY_MS);
-                        await realApp.close();
                         await delayPromise(DELAY_MS);
                     }
 

--- a/test/multi-runtime-interappbus.test.ts
+++ b/test/multi-runtime-interappbus.test.ts
@@ -1,13 +1,22 @@
 /* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code no-empty */
+import { conn } from './connect';
+import { Fin } from '../src/main';
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
 import { cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT, launchAndConnect } from './multi-runtime-utils';
 
 describe('Multi Runtime', function () {
+    let fin: Fin;
 
     this.retries(2);
     this.slow(TEST_TIMEOUT / 2 );
     this.timeout(TEST_TIMEOUT);
+
+    before(async () => {
+            await conn().then((a: Fin) => {
+                fin = a;
+            });
+    });
 
     beforeEach(async function () {
         return await cleanOpenRuntimes();
@@ -20,6 +29,8 @@ describe('Multi Runtime', function () {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 const topic = 'my-topic';
                 const data = 'hello';
+
+                await delayPromise(DELAY_MS);
 
                 await finA.InterApplicationBus.subscribe({ uuid: '*' }, topic, (message: any, source: any) => {
                     assert.equal(finB.wire.me.uuid, source.uuid, 'Expected source to be runtimeB');
@@ -41,6 +52,9 @@ describe('Multi Runtime', function () {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 const topic = 'my-topic';
                 const data = 'hello';
+
+                await delayPromise(DELAY_MS);
+
                 await finA.InterApplicationBus
                     .subscribe({ uuid: finB.wire.me.uuid }, topic, (message: any, source: any) => {
                         assert.equal(finB.wire.me.uuid, source.uuid, 'Expected source to be runtimeB');
@@ -63,6 +77,8 @@ describe('Multi Runtime', function () {
                 const topic = 'my-topic';
                 const data = 'hello';
 
+                await delayPromise(DELAY_MS);
+
                 await finA.InterApplicationBus.subscribe({ uuid: '*' }, topic, (message: any, source: any) => {
                     assert.equal(finB.wire.me.uuid, source.uuid, 'Expected source to be runtimeB');
                     assert.equal(data, message, 'Expected message to be the data sent');
@@ -84,6 +100,8 @@ describe('Multi Runtime', function () {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 const topic = 'my-topic';
                 const data = 'hello';
+
+                await delayPromise(DELAY_MS);
 
                 await finA.InterApplicationBus.subscribe({ uuid: finB.wire.me.uuid },
                     topic, (message: any, source: any) => {
@@ -109,6 +127,8 @@ describe('Multi Runtime', function () {
                 const topic = 'my-topic';
                 const expectedUuid = finB.wire.me.uuid;
 
+                await delayPromise(DELAY_MS);
+
                 await finA.InterApplicationBus.on('subscriber-added', (sub: any, b: any) => {
                     assert.equal(expectedUuid, sub.uuid, 'Expected UUIDs to match');
                     assert.equal(sub.topic, topic, 'Expected topics to match');
@@ -129,6 +149,8 @@ describe('Multi Runtime', function () {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 const topic = 'my-topic';
                 const expectedUuid = finB.wire.me.uuid;
+
+                await delayPromise(DELAY_MS);
 
                 await finA.InterApplicationBus.on('subscriber-removed', (sub: any, b: any) => {
                     assert.equal(expectedUuid, sub.uuid, 'Expected UUIDs to match');

--- a/test/multi-runtime-interappbus.test.ts
+++ b/test/multi-runtime-interappbus.test.ts
@@ -13,9 +13,7 @@ describe('Multi Runtime', function () {
     this.timeout(TEST_TIMEOUT);
 
     before(async () => {
-            await conn().then((a: Fin) => {
-                fin = a;
-            });
+        fin = await conn();
     });
 
     beforeEach(async function () {

--- a/test/multi-runtime-system.test.ts
+++ b/test/multi-runtime-system.test.ts
@@ -1,8 +1,13 @@
+/* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code no-empty */
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
-import { launchX, cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT, getRuntimeProcessInfo } from './multi-runtime-utils';
+import { launchAndConnect, cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT, getRuntimeProcessInfo } from './multi-runtime-utils';
 
-describe('Multi Runtime', () => {
+describe('Multi Runtime', function () {
+
+    this.retries(2);
+    this.slow(TEST_TIMEOUT / 2 );
+    this.timeout(TEST_TIMEOUT);
 
     function getAppConfig() {
         const appConfigTemplate = {
@@ -16,31 +21,27 @@ describe('Multi Runtime', () => {
             }
         };
 
-        // tslint:disable-next-line
         appConfigTemplate.uuid += Math.floor(Math.random() * 10000);
         return appConfigTemplate;
     }
 
-    afterEach(async () => {
+    beforeEach(async function () {
         return await cleanOpenRuntimes();
     });
 
-    describe('System', () => {
+    describe('System', function () {
 
-        describe('getAllApplications', () => {
+        describe('getAllApplications', function () {
             it('should return the application information from all runtimes', async function() {
-                // tslint:disable-next-line no-invalid-this
                 this.timeout(TEST_TIMEOUT);
 
                 const appConfigA = getAppConfig();
                 const appConfigB = getAppConfig();
                 const appConfigC = getAppConfig();
                 const appConfigD = getAppConfig();
-                const conns = await launchX(3);
-                // Why delay here?
-                await delayPromise(DELAY_MS);
 
-                const [finA, finB, finC] = conns;
+                const [finA, finB, finC] = await Promise.all([launchAndConnect(), launchAndConnect(), launchAndConnect()]);
+                await delayPromise(DELAY_MS);
 
                 const [appA, appB, appC, appD] = await Promise.all([finA.Application.create(appConfigA),
                 finB.Application.create(appConfigB),
@@ -61,15 +62,14 @@ describe('Multi Runtime', () => {
             });
         });
 
-        describe('getAllExternalApplications', () => {
+        describe('getAllExternalApplications', function () {
             it('should return the external application information from all runtimes', async function() {
-                // tslint:disable-next-line no-invalid-this
                 this.timeout(TEST_TIMEOUT);
 
-                const conns = await launchX(3);
+                const conns = await Promise.all([launchAndConnect(), launchAndConnect(), launchAndConnect()]);
+                const finA = conns[0];
                 await delayPromise(DELAY_MS);
 
-                const [finA] = conns;
                 const connStrings = conns.map(f => {
                     const conn = getRuntimeProcessInfo(f);
                     return `${conn.version}/${conn.port}/${conn.realm}`;
@@ -87,20 +87,16 @@ describe('Multi Runtime', () => {
             });
         });
 
-        describe('getAllWindows', () => {
+        describe('getAllWindows', function () {
             it('should return the window information from all runtimes', async function() {
-                // tslint:disable-next-line no-invalid-this
                 this.timeout(TEST_TIMEOUT);
 
                 const appConfigA = getAppConfig();
                 const appConfigB = getAppConfig();
                 const appConfigC = getAppConfig();
                 const appConfigD = getAppConfig();
-                const conns = await launchX(3);
-                // Why delay here?
+                const [finA, finB, finC] = await Promise.all([launchAndConnect(), launchAndConnect(), launchAndConnect()]);
                 await delayPromise(DELAY_MS);
-
-                const [finA, finB, finC] = conns;
 
                 const [appA, appB, appC, appD] = await Promise.all([finA.Application.create(appConfigA),
                 finB.Application.create(appConfigB),
@@ -128,20 +124,16 @@ describe('Multi Runtime', () => {
             });
         });
 
-        describe('getProcessList', () => {
+        describe('getProcessList', function () {
             it('should return the process information from all runtimes', async function() {
-                // tslint:disable-next-line no-invalid-this
                 this.timeout(TEST_TIMEOUT);
 
                 const appConfigA = getAppConfig();
                 const appConfigB = getAppConfig();
                 const appConfigC = getAppConfig();
                 const appConfigD = getAppConfig();
-                const conns = await launchX(3);
-                // Why delay here?
+                const [finA, finB, finC] = await Promise.all([launchAndConnect(), launchAndConnect(), launchAndConnect()]);
                 await delayPromise(DELAY_MS);
-
-                const [finA, finB, finC] = conns;
 
                 const [appA, appB, appC, appD] = await Promise.all([finA.Application.create(appConfigA),
                 finB.Application.create(appConfigB),

--- a/test/multi-runtime-system.test.ts
+++ b/test/multi-runtime-system.test.ts
@@ -29,9 +29,7 @@ describe('Multi Runtime', function () {
     }
 
     before(async () => {
-        await conn().then((a: Fin) => {
-            fin = a;
-        });
+        fin = await conn();
     });
 
     beforeEach(async function () {

--- a/test/multi-runtime-system.test.ts
+++ b/test/multi-runtime-system.test.ts
@@ -1,9 +1,12 @@
 /* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code no-empty */
+import { conn } from './connect';
+import { Fin } from '../src/main';
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
 import { launchAndConnect, cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT, getRuntimeProcessInfo } from './multi-runtime-utils';
 
 describe('Multi Runtime', function () {
+    let fin: Fin;
 
     this.retries(2);
     this.slow(TEST_TIMEOUT / 2 );
@@ -24,6 +27,12 @@ describe('Multi Runtime', function () {
         appConfigTemplate.uuid += Math.floor(Math.random() * 10000);
         return appConfigTemplate;
     }
+
+    before(async () => {
+        await conn().then((a: Fin) => {
+            fin = a;
+        });
+    });
 
     beforeEach(async function () {
         return await cleanOpenRuntimes();

--- a/test/multi-runtime-window.test.ts
+++ b/test/multi-runtime-window.test.ts
@@ -1,8 +1,14 @@
+/* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code no-empty */
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
-import { launchX, cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT } from './multi-runtime-utils';
+import { launchAndConnect, cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT } from './multi-runtime-utils';
 
-describe('Multi Runtime', () => {
+describe('Multi Runtime', function () {
+
+    this.retries(2);
+    this.slow(TEST_TIMEOUT / 2 );
+    this.timeout(TEST_TIMEOUT);
+
     let appConfigTemplate: any;
     function getAppConfig() {
         const appConfigTemplate = {
@@ -16,28 +22,22 @@ describe('Multi Runtime', () => {
             }
         };
 
-        // tslint:disable-next-line
         appConfigTemplate.uuid += Math.floor(Math.random() * 10000);
         return appConfigTemplate;
     }
 
-    beforeEach(() => {
+    beforeEach(async function () {
         appConfigTemplate = getAppConfig();
-    });
-    afterEach(async () => {
         return await cleanOpenRuntimes();
     });
 
-    describe('Window', () => {
+    describe('Window', function () {
 
-        describe('moveBy', () => {
+        describe('moveBy', function () {
             it('should move the Window by the given values', async function() {
-                // tslint:disable-next-line no-invalid-this
                 this.timeout(TEST_TIMEOUT);
 
-                const conns = await launchX(2);
-                const finA = conns[0];
-                const finB = conns[1];
+                const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 await delayPromise(DELAY_MS);
                 const realApp = await finB.Application.create(appConfigTemplate);
                 await realApp.run();
@@ -53,20 +53,16 @@ describe('Multi Runtime', () => {
             });
         });
 
-        describe('resizeTo', () => {
+        describe('resizeTo', function () {
             it('should resize the Window by the given values', async function() {
-                // tslint:disable-next-line no-invalid-this
                 this.timeout(TEST_TIMEOUT);
 
                 const resizeToVal = 200;
-                const conns = await launchX(2);
-                const finA = conns[0];
-                const finB = conns[1];
+                const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 await delayPromise(DELAY_MS);
                 const realApp = await finB.Application.create(appConfigTemplate);
                 await realApp.run();
-                const app = await finA.Application.wrap({ uuid: appConfigTemplate.uuid });
-                const win = await app.getWindow();
+                const win = await finA.Window.wrap({ uuid: appConfigTemplate.uuid, name: appConfigTemplate.uuid});
                 const bounds = await win.getBounds();
                 await win.resizeTo(resizeToVal, resizeToVal, 'top-left');
                 const postResizeBounds = await win.getBounds();
@@ -82,19 +78,15 @@ describe('Multi Runtime', () => {
         });
     });
 
-    describe('getState', () => {
+    describe('getState', function () {
         it('should return the state of the Window', async function() {
-            // tslint:disable-next-line no-invalid-this
             this.timeout(TEST_TIMEOUT);
 
-            const conns = await launchX(2);
-            const finA = conns[0];
-            const finB = conns[1];
+            const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
             await delayPromise(DELAY_MS);
             const realApp = await finB.Application.create(appConfigTemplate);
             await realApp.run();
-            const app = await finA.Application.wrap({ uuid: appConfigTemplate.uuid });
-            const win = await app.getWindow();
+            const win = await finA.Window.wrap({ uuid: appConfigTemplate.uuid, name: appConfigTemplate.uuid });
             const state = await win.getState();
             const expectedState = 'normal';
 
@@ -105,12 +97,9 @@ describe('Multi Runtime', () => {
         });
 
         it('should return the state of the Window post a minimize action', async function() {
-            // tslint:disable-next-line no-invalid-this
             this.timeout(TEST_TIMEOUT);
 
-            const conns = await launchX(2);
-            const finA = conns[0];
-            const finB = conns[1];
+            const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
             await delayPromise(DELAY_MS);
             const realApp = await finB.Application.create(appConfigTemplate);
             await realApp.run();

--- a/test/multi-runtime-window.test.ts
+++ b/test/multi-runtime-window.test.ts
@@ -1,9 +1,12 @@
 /* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code no-empty */
+import { conn } from './connect';
+import { Fin } from '../src/main';
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
 import { launchAndConnect, cleanOpenRuntimes, DELAY_MS, TEST_TIMEOUT } from './multi-runtime-utils';
 
 describe('Multi Runtime', function () {
+    let fin: Fin;
 
     this.retries(2);
     this.slow(TEST_TIMEOUT / 2 );
@@ -25,6 +28,12 @@ describe('Multi Runtime', function () {
         appConfigTemplate.uuid += Math.floor(Math.random() * 10000);
         return appConfigTemplate;
     }
+
+    before(async () => {
+        await conn().then((a: Fin) => {
+            fin = a;
+        });
+    });
 
     beforeEach(async function () {
         appConfigTemplate = getAppConfig();

--- a/test/multi-runtime-window.test.ts
+++ b/test/multi-runtime-window.test.ts
@@ -30,9 +30,7 @@ describe('Multi Runtime', function () {
     }
 
     before(async () => {
-        await conn().then((a: Fin) => {
-            fin = a;
-        });
+        fin = await conn();
     });
 
     beforeEach(async function () {

--- a/test/multi-runtime.test.ts
+++ b/test/multi-runtime.test.ts
@@ -1,13 +1,22 @@
 /* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code no-empty */
+import { conn } from './connect';
+import { Fin } from '../src/main';
 import * as assert from 'assert';
 import { delayPromise } from './delay-promise';
 import { cleanOpenRuntimes, DELAY_MS, getRuntimeProcessInfo, launchAndConnect, TEST_TIMEOUT } from './multi-runtime-utils';
 
 describe('Multi Runtime', function() {
+    let fin: Fin;
 
     this.retries(2);
     this.slow(TEST_TIMEOUT);
     this.timeout(TEST_TIMEOUT);
+
+    before(async () => {
+        await conn().then((a: Fin) => {
+            fin = a;
+        });
+    });
 
     beforeEach(async function() {
         return await cleanOpenRuntimes();

--- a/test/multi-runtime.test.ts
+++ b/test/multi-runtime.test.ts
@@ -13,9 +13,7 @@ describe('Multi Runtime', function() {
     this.timeout(TEST_TIMEOUT);
 
     before(async () => {
-        await conn().then((a: Fin) => {
-            fin = a;
-        });
+        fin = await conn();
     });
 
     beforeEach(async function() {

--- a/test/notification.test.ts
+++ b/test/notification.test.ts
@@ -1,6 +1,7 @@
 import { conn } from './connect';
 import * as assert from 'assert';
 import { Fin, Notification } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 // tslint:disable-next-line
 describe('Notification', function () {
@@ -8,7 +9,8 @@ describe('Notification', function () {
     let notification: Notification;
     // tslint:disable-next-line
     this.timeout(30000);
-    before(() => {
+    before(async() => {
+        await cleanOpenRuntimes();
         return conn().then(_fin => {
             fin = _fin;
             notification = fin.Notification.create({url: 'http://openfin.co'});

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,11 +1,13 @@
 import { conn } from './connect';
 import { Fin } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 describe('Plugin.', () => {
     let fin: Fin;
 
-    before(() => {
-        return conn().then((res) => fin = res);
+    before(async () => {
+        await cleanOpenRuntimes();
+        return fin = await conn();
     });
 
     describe('import()', () => {

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -7,7 +7,7 @@ describe('Plugin.', () => {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
 
     describe('import()', () => {

--- a/test/port-discovery.test.ts
+++ b/test/port-discovery.test.ts
@@ -6,8 +6,8 @@ import { connect as rawConnect, launch } from '../src/main';
 import { promiseMap } from '../src/launcher/util';
 import { ConnectConfig } from '../src/transport/wire';
 import { kill, killByPort } from './multi-runtime-utils';
-import { clean } from './connect';
 import { delayPromise } from './delay-promise';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 import * as path from 'path';
 // tslint:disable-next-line
 const appConfig = JSON.parse(fs.readFileSync('test/app.json').toString());
@@ -16,7 +16,9 @@ describe.skip('PortDiscovery.', function () {
     // do NOT use => function here for 'this' to be set properly
     // tslint:disable-next-line
     this.timeout(60000);
-    before(clean);
+    before(async () => {
+        return  await cleanOpenRuntimes();
+    });
     let spawns = 0;
     function makeConfig(config: any = {}): ConnectConfig {
         const defaultRconfig = {

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -8,9 +8,9 @@ describe('System.', function () {
     // tslint:disable-next-line
     this.timeout(30000);
 
-    beforeEach(async () => {
+    before(async () => {
         await cleanOpenRuntimes();
-        return conn().then((a: Fin) => fin = a);
+        return fin = await conn();
     });
 
     describe('getVersion()', () => {

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -10,7 +10,7 @@ describe('System.', function () {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
 
     describe('getVersion()', () => {

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -1,13 +1,15 @@
 import { conn } from './connect';
 import { Fin } from '../src/main';
 import * as assert from 'assert';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 describe('System.', function () {
     let fin: Fin;
     // tslint:disable-next-line
     this.timeout(30000);
 
-    beforeEach(() => {
+    beforeEach(async () => {
+        await cleanOpenRuntimes();
         return conn().then((a: Fin) => fin = a);
     });
 

--- a/test/window-event.test.ts
+++ b/test/window-event.test.ts
@@ -24,7 +24,7 @@ describe('Window.', function() {
 
         before(async () => {
             await cleanOpenRuntimes();
-            return fin = await conn();
+            fin = await conn();
         });
 
         describe('"closed"', () => {

--- a/test/window-event.test.ts
+++ b/test/window-event.test.ts
@@ -24,7 +24,7 @@ describe('Window.', function() {
 
         before(async () => {
             await cleanOpenRuntimes();
-            return conn().then(a => fin = a);
+            return fin = await conn();
         });
 
         describe('"closed"', () => {

--- a/test/window-event.test.ts
+++ b/test/window-event.test.ts
@@ -3,6 +3,7 @@ import { conn } from './connect';
 import { delayPromise } from './delay-promise';
 import * as assert from 'assert';
 import { Fin } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 // tslint:disable-next-line:no-function-expression
 describe('Window.', function() {
@@ -21,7 +22,8 @@ describe('Window.', function() {
             }
         };
 
-        before(() => {
+        before(async () => {
+            await cleanOpenRuntimes();
             return conn().then(a => fin = a);
         });
 

--- a/test/window.test.ts
+++ b/test/window.test.ts
@@ -22,7 +22,7 @@ describe('Window.', function() {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return conn().then(a => fin = a);
+        return fin = await conn();
     });
 
     beforeEach(() => {

--- a/test/window.test.ts
+++ b/test/window.test.ts
@@ -22,7 +22,7 @@ describe('Window.', function() {
 
     before(async () => {
         await cleanOpenRuntimes();
-        return fin = await conn();
+        fin = await conn();
     });
 
     beforeEach(() => {

--- a/test/window.test.ts
+++ b/test/window.test.ts
@@ -2,6 +2,7 @@ import { conn } from './connect';
 import * as assert from 'assert';
 import { connect as rawConnect, Fin, Application, Window } from '../src/main';
 import { delayPromise } from './delay-promise';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 describe('Window.', function() {
     let fin: Fin;
@@ -19,7 +20,8 @@ describe('Window.', function() {
     // tslint:disable-next-line
     this.timeout(30000);
 
-    before(() => {
+    before(async () => {
+        await cleanOpenRuntimes();
         return conn().then(a => fin = a);
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es6",
+        "target": "ES2017",
         "lib": [
             "dom",
             "es7"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES2017",
+        "target": "es6",
         "lib": [
             "dom",
             "es7"


### PR DESCRIPTION
## Had to make a number of changes to make the Multi Runtime tests reliable.

#### Remove the conn.clean function
Without the main runtime instance where all tests are run the RVM closes, the multi runtime tests run on disconnected runtimes(directly launched without the RVM) so they do not keep the RVM open.

#### Added cleanOpenruntimes to all tests
afterEach does not seem to run reliably on tests that timeout, this is a way to ensure a clean test bed before each test module.

#### Added conn to multi runtime tests
If you launch the Multi runtime tests directly with a --grep, they should be anchored by the main runtime instance.

#### Added retries to multi runtime tests
Arguably not needed but this rules out odd timing we could face while cleaning directories or closing active runtimes.

#### Multi Runtime tests no longer open Apps
We did not need applications on the Multi Runtime tests, so removed them. Cleaner shutdown sequences.

#### Moved all tests to use `function` instead of arrow syntax.
Limitation with mocha and `this` scoping.

#### Moved launching runtimes from serial (`launchX`) to Promise.all
Understand why we did this but we no longer need to do it.

#### Moved Multi Runtime `closed` tests to started
Currently a runtime Bug.

#### Multi Runtime tests assign a port to be used instead of "discovering" it.
This is related to a Runtime bug where attaching to the console alters it's behaviour.

#### Added standard set of tslint ignore rules for tests.


