### PR TITLE
Fixed issue with the webpack grunt task where it was not reporting the errors correctly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,14 +132,14 @@ module.exports = function (grunt) {
             if (err) {
                 const error = err ? err.message : 'webpack error';
                 if (err.details) {
-                    grunt.fail.fatal(err.details, [3]);
+                    grunt.fail.fatal(err.details, 3);
                 }
             } else if(stats.hasErrors()) {
                 const info = stats.toJson();
                 grunt.fail.fatal(info.errors, 3);
             } else if(stats.hasWarnings()) {
                 const info = stats.toJson();
-                grunt.fail.warn(info.warnings, [6]);
+                grunt.fail.warn(info.warnings, 6);
             } else {
                 grunt.log.ok('webpack task done');
                 done();

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,13 +124,22 @@ module.exports = function (grunt) {
         }
     });
 
+    //using the node webpack API: https://webpack.js.org/api/node/
+    //will use Task Error or Warning grunt codes based on webpack results: https://gruntjs.com/exit-codes
     grunt.registerTask('webpack', function () {
         const done = this.async();
         webpack(webpackConfig, (err, stats) => {
-            if (err || stats.hasErrors()) {
+            if (err) {
                 const error = err ? err.message : 'webpack error';
-                grunt.log.error(error);
-                done(err);
+                if (err.details) {
+                    grunt.fail.fatal(err.details, [3]);
+                }
+            } else if(stats.hasErrors()) {
+                const info = stats.toJson();
+                grunt.fail.fatal(info.errors, 3);
+            } else if(stats.hasWarnings()) {
+                const info = stats.toJson();
+                grunt.fail.warn(info.warnings, [6]);
             } else {
                 grunt.log.ok('webpack task done');
                 done();

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,7 +1,7 @@
 import Transport, { Message } from '../transport/transport';
 import { Identity } from '../identity';
 import { EventEmitter } from 'events';
-import { promiseMap } from '../launcher/util';
+import { promiseMap } from '../util/promises';
 
 export interface RuntimeEvent extends Identity {
     topic: string;

--- a/src/launcher/nix-launch.ts
+++ b/src/launcher/nix-launch.ts
@@ -2,7 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { ChildProcess, spawn } from 'child_process';
 import { ConfigWithRuntime } from '../transport/wire';
-import { promisify, resolveRuntimeVersion, rmDir, downloadFile, unzip, resolveDir, exists } from './util';
+import { promisify } from '../util/promises';
+import { resolveRuntimeVersion, rmDir, downloadFile, unzip, resolveDir, exists } from './util';
 
 const mkdir = promisify(fs.mkdir);
 

--- a/src/launcher/util.ts
+++ b/src/launcher/util.ts
@@ -2,12 +2,7 @@ import * as path from 'path';
 import * as https from 'https';
 import * as fs from 'fs';
 import { exec } from 'child_process';
-
-export function promisify(func: Function): (...args: any[]) => Promise<any> {
-    return (...args: any[]) => new Promise((resolve, reject) => {
-        func(...args, (err: Error, val: any) => err ? reject(err) : resolve(val));
-    });
-}
+import { promisify, promiseMap } from '../util/promises';
 
 const stat = promisify(fs.stat);
 export async function exists(path: string): Promise<Boolean> {
@@ -148,21 +143,4 @@ export async function resolveDir(base: string, paths: string[]): Promise<string>
             return err.code === 'EEXIST' ? err.path : Promise.reject(err);
         }
     }, Promise.resolve(base));
-}
-
-export async function promiseMap<T, S>(arr: T[], asyncF: (x: T, i: number, r: T[]) => Promise<S>): Promise<S[]> {
-    return Promise.all<S>(arr.map(asyncF));
-}
-
-export type asyncF<T> = (...args: any[]) => Promise<T>;
-export async function serial<T>(arr: asyncF<T>[]): Promise<T[]> {
-    const ret: T[] = [];
-    for (const func of arr) {
-        const next = await func();
-        ret.push(next);
-    }
-    return ret;
-}
-export async function promiseMapSerial<T>(arr: any[], func: asyncF<T>): Promise<T[]> {
-    return serial(arr.map((value, index, array) => () => func(value, index, array)));
 }

--- a/src/util/normalize-config.ts
+++ b/src/util/normalize-config.ts
@@ -2,7 +2,7 @@ import { ConnectConfig, isExternalConfig, InternalConnectConfig, ExternalConfig,
 import { Url, parse } from 'url';
 import { IncomingMessage } from 'http';
 import * as fs from 'fs';
-import { promisify } from '../launcher/util';
+import { promisify } from '../util/promises';
 
 async function readLocalConfig(location: string): Promise<any> {
     const txt = await promisify(fs.readFile)(location);

--- a/src/util/promises.ts
+++ b/src/util/promises.ts
@@ -1,0 +1,22 @@
+export function promisify(func: Function): (...args: any[]) => Promise<any> {
+    return (...args: any[]) => new Promise((resolve, reject) => {
+        func(...args, (err: Error, val: any) => err ? reject(err) : resolve(val));
+    });
+}
+
+export async function promiseMap<T, S>(arr: T[], asyncF: (x: T, i: number, r: T[]) => Promise<S>): Promise<S[]> {
+    return Promise.all<S>(arr.map(asyncF));
+}
+
+export type asyncF<T> = (...args: any[]) => Promise<T>;
+export async function serial<T>(arr: asyncF<T>[]): Promise<T[]> {
+    const ret: T[] = [];
+    for (const func of arr) {
+        const next = await func();
+        ret.push(next);
+    }
+    return ret;
+}
+export async function promiseMapSerial<T>(arr: any[], func: asyncF<T>): Promise<T[]> {
+    return serial(arr.map((value, index, array) => () => func(value, index, array)));
+}

--- a/test/launcher.test.ts
+++ b/test/launcher.test.ts
@@ -4,7 +4,8 @@ import * as os from 'os';
 import * as path from 'path';
 import Launcher from '../src/launcher/launcher';
 import { download, getRuntimePath, OsConfig, getUrl } from '../src/launcher/nix-launch';
-import { resolveRuntimeVersion, rmDir, promiseMap } from '../src/launcher/util';
+import { resolveRuntimeVersion, rmDir } from '../src/launcher/util';
+import { promiseMap } from '../src/util/promises';
 
 describe('Launcher', () => {
     describe('Resolve Runtime', () => {

--- a/test/multi-runtime-utils.ts
+++ b/test/multi-runtime-utils.ts
@@ -6,7 +6,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ChildProcess from 'child_process';
 import { connect as rawConnect, Fin } from '../src/main';
-import { resolveDir, first, serial, promiseMap } from '../src/launcher/util';
+import { resolveDir, first } from '../src/launcher/util';
+import { serial, promiseMap } from '../src/util/promises';
 import { delayPromise } from './delay-promise';
 
 const appConfig = JSON.parse(fs.readFileSync(path.resolve('test/app.json')).toString());

--- a/test/port-discovery.test.ts
+++ b/test/port-discovery.test.ts
@@ -3,7 +3,7 @@ import Launcher from '../src/launcher/launcher';
 import * as assert from 'assert';
 import * as fs from 'fs';
 import { connect as rawConnect, launch } from '../src/main';
-import { promiseMap } from '../src/launcher/util';
+import { promiseMap } from '../src/util/promises';
 import { ConnectConfig } from '../src/transport/wire';
 import { kill, killByPort } from './multi-runtime-utils';
 import { delayPromise } from './delay-promise';


### PR DESCRIPTION
Had an issue in the webpack task where errors were not being reported correctly. Once that was fixed I was able to see the error:

Base was importing functions from launcher/utils and webpack could not pack `fs` and `child_process`. So I moved the utils functions to the utils folder.