### PR TITLE
Simplify External Services Tests

### DIFF
--- a/test/external-services.test.ts
+++ b/test/external-services.test.ts
@@ -35,23 +35,17 @@ describe ('External Services', () => {
             const url = appConfig.startup_app.url;
             const newUrl = url.slice(0, url.lastIndexOf('/')) + '/client.html';
 
-            const clientConfig : any = {
-                ...appConfig,
-                'startup_app': {
-                    'name': 'Services',
-                    'description': 'services test app',
-                    'url': newUrl,
-                    'uuid': 'service-client-test',
-                    'autoShow': true,
-                    'saveWindowState': false,
-                    'nonPersistent': true,
-                    'experimental': {
-                        'v2Api': true
-                    }
+            const clientConfig = {
+                'name': 'service-client-test',
+                'url': newUrl,
+                'uuid': 'service-client-test',
+                'autoShow': true,
+                'saveWindowState': false,
+                'nonPersistent': true,
+                'experimental': {
+                    'v2Api': true
                 }
             };
-
-            fs.writeFileSync(path.resolve('test/client.json'), JSON.stringify(clientConfig));
 
             async function test () {
                 const spy = sinon.spy();
@@ -63,7 +57,8 @@ describe ('External Services', () => {
                 provider.onConnection(c => {
                     spy();
                 });
-                await launch({manifestUrl: path.resolve('test', 'client.json')});
+                const client = await fin.Application.create(clientConfig);
+                await client.run();
                 await fin.InterApplicationBus.subscribe({uuid: 'service-client-test'}, 'return', (msg: any) => {
                     assert(spy.calledTwice && msg === 'return-test', 'Did not get IAB from dispatch');
                     done();
@@ -86,26 +81,21 @@ describe ('External Services', () => {
             const url = appConfig.startup_app.url;
             const newUrl = url.slice(0, url.lastIndexOf('/')) + '/service.html';
 
-            const serviceConfig : any = {
-                ...appConfig,
-                'startup_app': {
-                    'name': 'Service Provider',
-                    'description': 'Service Provider test app',
-                    'url': newUrl,
-                    'uuid': 'service-provider-test',
-                    'autoShow': true,
-                    'saveWindowState': false,
-                    'nonPersistent': true,
-                    'experimental': {
-                        'v2Api': true
-                    }
+            const serviceConfig = {
+                'name': 'service-provider-test',
+                'url': newUrl,
+                'uuid': 'service-provider-test',
+                'autoShow': true,
+                'saveWindowState': false,
+                'nonPersistent': true,
+                'experimental': {
+                    'v2Api': true
                 }
             };
 
-            fs.writeFileSync(path.resolve('test/service.json'), JSON.stringify(serviceConfig));
-
             async function test() {
-                await launch({manifestUrl: path.resolve('test', 'service.json')});
+                const service = await fin.Application.create(serviceConfig);
+                await service.run();
                 const client = await fin.Service.connect({uuid: 'service-provider-test'});
                 client.dispatch('test').then(res => {
                     assert(res === 'return-test');

--- a/test/external-services.test.ts
+++ b/test/external-services.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { conn } from './connect';
-import { Fin, launch } from '../src/main';
+import { Fin } from '../src/main';
 import * as path from 'path';
 import { cleanOpenRuntimes } from './multi-runtime-utils';
 import { delayPromise } from './delay-promise';


### PR DESCRIPTION
Remove usage of launch for tests, create and run app as normal.