### PR TITLE
Feature/run-4065 global hotkeys

### DIFF
--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -12,7 +12,8 @@
             "out/src/api/notification",
             "out/src/api/external-application",
             "out/src/api/frame",
-            "out/src/api/plugin"
+            "out/src/api/plugin",
+            "out/src/api/global-hotkey"
         ]
     },
     "tags": {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -15,9 +15,13 @@ export class Base {
         this.wire = wire;
     }
 
-    protected get topic()
-    : string {
-        return this.constructor.name.replace('_', '').toLowerCase();
+    private _topic: string;
+    protected get topic() : string {
+        return this._topic || this.constructor.name.replace('_', '').toLowerCase();
+    }
+
+    protected set topic(t: string) {
+        this._topic = t;
     }
 
     get me(): Identity {

--- a/src/api/fin.ts
+++ b/src/api/fin.ts
@@ -10,6 +10,7 @@ import ExternalApplication from './external-application/external-application';
 import _FrameModule from './frame/frame';
 import Plugin from './plugin/plugin';
 import { Service } from './services';
+import GlobalHotkey from './global-hotkey';
 import { Identity } from '../identity';
 
 export default class Fin extends EventEmitter {
@@ -25,6 +26,7 @@ export default class Fin extends EventEmitter {
     public Frame: _FrameModule;
     public Plugin: Plugin;
     public Service: Service;
+    public GlobalHotkey: GlobalHotkey;
 
     get me(): Identity {
         return this.wire.me;
@@ -43,6 +45,7 @@ export default class Fin extends EventEmitter {
         this.Frame = new _FrameModule(wire);
         this.Plugin = new Plugin(wire);
         this.Service = new Service(wire);
+        this.GlobalHotkey = new GlobalHotkey(wire);
 
         //Handle disconnect events
         wire.on('disconnected', () => {

--- a/src/api/global-hotkey/index.ts
+++ b/src/api/global-hotkey/index.ts
@@ -1,0 +1,64 @@
+import { EmitterBase } from '../base';
+import Transport from '../../transport/transport';
+
+const apiActions = {
+    REGISTER: 'global-hotkey-register',
+    UNREGISTER: 'global-hotkey-unregister',
+    UNREGISTER_ALL: 'global-hotkey-unregister-all',
+    IS_REGISTERED: 'global-hotkey-is-registered'
+};
+
+/**
+ * The GlobalHotkey module can register/unregister a global hotkeys.
+ * @namespace
+ */
+export default class GlobalHotkey extends EmitterBase {
+
+    constructor(wire: Transport) {
+        super(wire);
+        this.topic = 'global-hotkey';
+    }
+
+    /**
+     * Registers a global hotkey with the operating system.
+     * @return {Promise.<void>}
+     * @tutorial GlobalHotkey.register
+     */
+    public async register(hotkey: string, listener: (...args: any[]) => void): Promise<void> {
+        this.emitter.on(hotkey, listener);
+        await this.wire.sendAction(apiActions.REGISTER, { hotkey });
+        return void 0;
+    }
+
+    /**
+     * Unregisters a global hotkey with the operating system.
+     * @return {Promise.<void>}
+     * @tutorial GlobalHotkey.unregister
+     */
+    public async unregister(hotkey: string): Promise<void> {
+        this.emitter.removeAllListeners(hotkey);
+        await this.wire.sendAction(apiActions.UNREGISTER, { hotkey });
+        return void 0;
+    }
+
+    /**
+     * Unregisters all global hotkeys for the current application.
+     * @return {Promise.<void>}
+     * @tutorial GlobalHotkey.unregisterAll
+     */
+    public async unregisterAll(): Promise<void> {
+        this.emitter.removeAllListeners();
+        await this.wire.sendAction(apiActions.UNREGISTER_ALL, {});
+        return void 0;
+    }
+
+    /**
+     * Checks if a given hotkey has been registered
+     * @return {Promise.<bookean>}
+     * @tutorial GlobalHotkey.isRegistered
+     */
+    public async isRegistered(hotkey: string): Promise<boolean> {
+        const { payload: { data }} = await this.wire.sendAction(apiActions.IS_REGISTERED, { hotkey });
+        return data;
+    }
+}

--- a/test/global-hotkey.test.ts
+++ b/test/global-hotkey.test.ts
@@ -1,0 +1,24 @@
+/* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code */
+import { conn } from './connect';
+import * as assert from 'assert';
+import { Fin } from '../src/main';
+import { cleanOpenRuntimes } from './multi-runtime-utils';
+
+// tslint:disable-next-line
+const sinon = require('sinon');
+
+describe('GlobalHotkey.', function() {
+    let fin: Fin;
+    const hotkey = 'CommandOrControl+X';
+
+    before(async () => {
+        await cleanOpenRuntimes();
+        fin = await conn();
+    });
+
+    it('Should register successfully', async() => {
+        const spy = sinon.spy();
+        await fin.GlobalHotkey.register(hotkey, () => spy);
+        assert.ok(true);
+    });
+});

--- a/test/global-hotkey.test.ts
+++ b/test/global-hotkey.test.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-invalid-this no-function-expression insecure-random mocha-no-side-effect-code */
 import { conn } from './connect';
 import * as assert from 'assert';
-import { Fin } from '../src/main';
+import { Fin, connect as rawConnect } from '../src/main';
 import { cleanOpenRuntimes } from './multi-runtime-utils';
 
 // tslint:disable-next-line
@@ -16,9 +16,143 @@ describe('GlobalHotkey.', function() {
         fin = await conn();
     });
 
-    it('Should register successfully', async() => {
+    beforeEach(async () => {
+        await fin.GlobalHotkey.unregisterAll();
+    });
+
+    it('should detect if a hotkey is registered', async() => {
         const spy = sinon.spy();
-        await fin.GlobalHotkey.register(hotkey, () => spy);
-        assert.ok(true);
+        const expectFalse = await fin.GlobalHotkey.isRegistered(hotkey);
+
+        assert.deepStrictEqual(expectFalse, false, 'Expected hotkey not to be registered');
+        await fin.GlobalHotkey.register(hotkey, spy);
+        const expectTrue = await fin.GlobalHotkey.isRegistered(hotkey);
+
+        assert.deepStrictEqual(expectTrue, true, 'Expected hotkey to be registered');
+    });
+
+    it('should unregister a hotkey', async() => {
+        const spy = sinon.spy();
+        await fin.GlobalHotkey.register(hotkey, spy);
+        const expectTrue = await fin.GlobalHotkey.isRegistered(hotkey);
+
+        assert.deepStrictEqual(expectTrue, true, 'Expected hotkey to be registered');
+
+        await fin.GlobalHotkey.unregister(hotkey);
+        const expectFalse = await fin.GlobalHotkey.isRegistered(hotkey);
+
+        assert.deepStrictEqual(expectFalse, false, 'Expected hotkey not to be registered');
+    });
+
+    it('should register multiple hotkeys', async() => {
+        const spy = sinon.spy();
+        const hotkey2 = 'CommandOrControl+Y';
+        await fin.GlobalHotkey.register(hotkey2, spy);
+        await fin.GlobalHotkey.register(hotkey, spy);
+        const expectTrue = await fin.GlobalHotkey.isRegistered(hotkey);
+        const expectTrue2 = await fin.GlobalHotkey.isRegistered(hotkey2);
+
+        assert.deepStrictEqual(expectTrue, true, 'Expected hotkey to be registered');
+        assert.deepStrictEqual(expectTrue2, true, 'Expected hotkey to be registered');
+        await fin.GlobalHotkey.unregisterAll();
+    });
+
+    it('should unregister only specified hotkeys', async() => {
+        const spy = sinon.spy();
+        const hotkey2 = 'CommandOrControl+Y';
+        await fin.GlobalHotkey.register(hotkey2, spy);
+        await fin.GlobalHotkey.register(hotkey, spy);
+
+        await fin.GlobalHotkey.unregister(hotkey2);
+        const expectTrue = await fin.GlobalHotkey.isRegistered(hotkey);
+        const expectFalse = await fin.GlobalHotkey.isRegistered(hotkey2);
+
+        assert.deepStrictEqual(expectFalse, false, 'Expected hotkey not to be registered');
+        assert.deepStrictEqual(expectTrue, true, 'Expected hotkey to be registered');
+        await fin.GlobalHotkey.unregisterAll();
+    });
+
+    it('should unregister all hotkeys', async() => {
+        const spy = sinon.spy();
+        const hotkey2 = 'CommandOrControl+Y';
+        await fin.GlobalHotkey.register(hotkey2, spy);
+        await fin.GlobalHotkey.register(hotkey, spy);
+
+        await fin.GlobalHotkey.unregisterAll();
+        const expectFalse = await fin.GlobalHotkey.isRegistered(hotkey);
+        const expectFalse2 = await fin.GlobalHotkey.isRegistered(hotkey2);
+
+        assert.deepStrictEqual(expectFalse, false, 'Expected hotkey not to be registered');
+        assert.deepStrictEqual(expectFalse2, false, 'Expected hotkey not to be registered');
+
+    });
+
+    it('should raise registered events', function(done: any) {
+        async function test() {
+            const spy = sinon.spy();
+            await fin.GlobalHotkey.on('registered', async (evt) => {
+                assert.deepStrictEqual(evt.hotkey, hotkey, 'Expected hotkey from event to match');
+                await fin.GlobalHotkey.removeAllListeners('registered');
+                done();
+            });
+            await fin.GlobalHotkey.register(hotkey, spy);
+        }
+
+        test();
+    });
+
+    it('should raise unregistered events', function(done: any) {
+        async function test() {
+            const spy = sinon.spy();
+            await fin.GlobalHotkey.on('unregistered', async (evt) => {
+                assert.deepStrictEqual(evt.hotkey, hotkey, 'Expected hotkey from event to match');
+                await fin.GlobalHotkey.removeAllListeners('uregistered');
+                done();
+            });
+            await fin.GlobalHotkey.register(hotkey, spy);
+            await fin.GlobalHotkey.unregister(hotkey);
+        }
+
+        test();
+    });
+
+    it('should fail to register a reserved hotkey', async() => {
+        const spy = sinon.spy();
+        const reservedHotkey = 'CommandOrControl+Plus';
+        try {
+            await fin.GlobalHotkey.register(reservedHotkey, spy);
+        } catch (err) {
+            assert.ok(err instanceof Error, 'Expected error thrown to be an instance of Error');
+            assert.equal(err.message, 'Error: Failed to register Hotkey: CommandOrControl+Plus, is reserved');
+        }
+    });
+
+    it('should allow multiple registrations from the same connection', async() => {
+        const spy = sinon.spy();
+        const spy2 = sinon.spy();
+
+        await fin.GlobalHotkey.register(hotkey, spy);
+        await fin.GlobalHotkey.register(hotkey, spy2);
+        const expectTrue = await fin.GlobalHotkey.isRegistered(hotkey);
+
+        assert.deepStrictEqual(expectTrue, true, 'Expected hotkey to be registered');
+    });
+
+    it('should fail to register a hotkey if it owned by a different uuid', async() => {
+        const spy = sinon.spy();
+        const spy2 = sinon.spy();
+
+        const fin2 = await rawConnect({
+            address: 'ws://localhost:9696',
+            uuid: 'second_uuid'
+        });
+
+        await fin.GlobalHotkey.register(hotkey, spy);
+        try {
+            await fin2.GlobalHotkey.register(hotkey, spy2);
+        } catch (err) {
+            assert.ok(err instanceof Error, 'Expected error thrown to be an instance of Error');
+            assert.equal(err.message, 'Error: Failed to register Hotkey: CommandOrControl+X, already registered');
+        }
     });
 });

--- a/test/global-hotkey.test.ts
+++ b/test/global-hotkey.test.ts
@@ -106,7 +106,7 @@ describe('GlobalHotkey.', function() {
             const spy = sinon.spy();
             await fin.GlobalHotkey.on('unregistered', async (evt) => {
                 assert.deepStrictEqual(evt.hotkey, hotkey, 'Expected hotkey from event to match');
-                await fin.GlobalHotkey.removeAllListeners('uregistered');
+                await fin.GlobalHotkey.removeAllListeners('unregistered');
                 done();
             });
             await fin.GlobalHotkey.register(hotkey, spy);

--- a/tutorials/GlobalHotkey.isRegistered.md
+++ b/tutorials/GlobalHotkey.isRegistered.md
@@ -1,0 +1,14 @@
+Checks if a given hotkey has been registered.
+
+# Example
+```js
+const hotkey = 'CommandOrControl+X';
+
+fin.GlobalHotkey.isRegistered(hotkey)
+.then((registered) => {
+    console.log(`hotkey ${hotkey} is registered ? ${registered}`);
+})
+.catch(err => {
+    console.log('Error unregistering the hotkey', err);
+});
+```

--- a/tutorials/GlobalHotkey.register.md
+++ b/tutorials/GlobalHotkey.register.md
@@ -1,16 +1,16 @@
 Registers a global hotkey with the operating system. The `hotkey` parameter expects an electron compatible [accelerator](https://github.com/electron/electron/blob/master/docs/api/accelerator.md) and the `listener` will be called if the `hotkey` is pressed by the user. If successfull, the hotkey will be 'claimed' by the application, meaning that this register call can be called multiple times from within the same application but will fail if another application has registered the hotkey.
 
 The register call will fail if given any of these reserved Hotkeys:
-* CommandOrControl+0
-* CommandOrControl+=
-* CommandOrControl+Plus
-* CommandOrControl+-
-* CommandOrControl+_
-* CommandOrControl+Shift+I
-* F5
-* CommandOrControl+R
-* Shift+F5
-* CommandOrControl+Shift+R
+* `CommandOrControl+0`
+* `CommandOrControl+=`
+* `CommandOrControl+Plus`
+* `CommandOrControl+-`
+* `CommandOrControl+_`
+* `CommandOrControl+Shift+I`
+* `F5`
+* `CommandOrControl+R`
+* `Shift+F5`
+* `CommandOrControl+Shift+R`
 
 Raises the `registered` event.
 
@@ -22,7 +22,7 @@ fin.GlobalHotkey.register(hotkey, () => {
     console.log(`${hotkey} pressed`);
 })
 .then(() => {
-    console.log('Here we go magic')
+    console.log('Success');
 })
 .catch(err => {
     console.log('Error registering the hotkey', err);

--- a/tutorials/GlobalHotkey.register.md
+++ b/tutorials/GlobalHotkey.register.md
@@ -1,0 +1,30 @@
+Registers a global hotkey with the operating system. The `hotkey` parameter expects an electron compatible (accelerator)[https://github.com/electron/electron/blob/master/docs/api/accelerator.md] and the `listener` will be called if the `hotkey` is pressed by the user. If successfull, the hotkey will be 'claimed' by the application, meaning that this register call can be called multiple times from within the same application but will fail if another application has registered the hotkey.
+
+The register call will fail if given any of these reserved Hotkeys:
+* CommandOrControl+0
+* CommandOrControl+=
+* CommandOrControl+Plus
+* CommandOrControl+-
+* CommandOrControl+_
+* CommandOrControl+Shift+I
+* F5
+* CommandOrControl+R
+* Shift+F5
+* CommandOrControl+Shift+R
+
+Raises the `registered` event.
+
+# Example
+```js
+const hotkey = 'CommandOrControl+X';
+
+fin.GlobalHotkey.register(hotkey, () => {
+    console.log(`${hotkey} pressed`);
+})
+.then(() => {
+    console.log('Here we go magic')
+})
+.catch(err => {
+    console.log('Error registering the hotkey', err);
+});
+```

--- a/tutorials/GlobalHotkey.register.md
+++ b/tutorials/GlobalHotkey.register.md
@@ -1,4 +1,4 @@
-Registers a global hotkey with the operating system. The `hotkey` parameter expects an electron compatible (accelerator)[https://github.com/electron/electron/blob/master/docs/api/accelerator.md] and the `listener` will be called if the `hotkey` is pressed by the user. If successfull, the hotkey will be 'claimed' by the application, meaning that this register call can be called multiple times from within the same application but will fail if another application has registered the hotkey.
+Registers a global hotkey with the operating system. The `hotkey` parameter expects an electron compatible [accelerator](https://github.com/electron/electron/blob/master/docs/api/accelerator.md) and the `listener` will be called if the `hotkey` is pressed by the user. If successfull, the hotkey will be 'claimed' by the application, meaning that this register call can be called multiple times from within the same application but will fail if another application has registered the hotkey.
 
 The register call will fail if given any of these reserved Hotkeys:
 * CommandOrControl+0

--- a/tutorials/GlobalHotkey.unregister.md
+++ b/tutorials/GlobalHotkey.unregister.md
@@ -8,7 +8,7 @@ const hotkey = 'CommandOrControl+X';
 
 fin.GlobalHotkey.unregister(hotkey)
 .then(() => {
-    console.log('success');
+    console.log('Success');
 })
 .catch(err => {
     console.log('Error unregistering the hotkey', err);

--- a/tutorials/GlobalHotkey.unregister.md
+++ b/tutorials/GlobalHotkey.unregister.md
@@ -1,0 +1,16 @@
+Unregisters a global hotkey with the operating system. This method will unregister all existing registrations of the hotkey within the application.
+
+Raises the `unregistered` event.
+
+# Example
+```js
+const hotkey = 'CommandOrControl+X';
+
+fin.GlobalHotkey.unregister(hotkey)
+.then(() => {
+    console.log('success');
+})
+.catch(err => {
+    console.log('Error unregistering the hotkey', err);
+});
+```

--- a/tutorials/GlobalHotkey.unregisterAll.md
+++ b/tutorials/GlobalHotkey.unregisterAll.md
@@ -6,7 +6,7 @@ Raises the `unregistered` event for each hotkey unregistered.
 ```js
 fin.GlobalHotkey.unregisterAll()
 .then(() => {
-    console.log('success');
+    console.log('Success');
 })
 .catch(err => {
     console.log('Error unregistering all hotkeys for this application', err);

--- a/tutorials/GlobalHotkey.unregisterAll.md
+++ b/tutorials/GlobalHotkey.unregisterAll.md
@@ -1,0 +1,14 @@
+Unregisters all global hotkeys for the current application.
+
+Raises the `unregistered` event for each hotkey unregistered.
+
+# Example
+```js
+fin.GlobalHotkey.unregisterAll()
+.then(() => {
+    console.log('success');
+})
+.catch(err => {
+    console.log('Error unregistering all hotkeys for this application', err);
+});
+```


### PR DESCRIPTION
### Adding support for global hotkeys. 

The API will register a given hotkey to the requesting uuid. Within the same uuid the API is asymmetrical, meaning  you can call the register method multiple times and attach several listeners to the same hotkey but a single unregister call will remove all listeners. To compensate for this fact events are raised on register/unregister.


Tests run with js-adapter.asar and hadouken-js-adapter module replaced:

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b18a93af2f2e22fa4b7c2ab)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b18aa7df2f2e22fa4b7c2ac)

### TODO:

- [ ] Add test runner tests
- [ ] javascript-adapter implementation
- [ ] Manual test app tests