### PR TITLE
fixed typescript error

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -197,5 +197,5 @@ export class Reply<TOPIC extends string, TYPE extends string | void> implements 
 function createKey(listener: RuntimeEvent): string {
     const { name, uuid, topic, type } = listener;
 
-    return `${name}/${uuid}/${topic}/${type}`;
+    return `${name}/${uuid}/${topic}/${<string>type}`;
 }


### PR DESCRIPTION
TSC was throwing an error for a clean repo, because `type` as a symbol couldn't be converted to a string