### PR TITLE
Fixed unregister all bug.

### DIFF
--- a/src/api/global-hotkey/index.ts
+++ b/src/api/global-hotkey/index.ts
@@ -8,6 +8,11 @@ const enum apiActions {
     IS_REGISTERED = 'global-hotkey-is-registered'
 }
 
+const enum nonHotkeyEvents {
+    REGISTERED = 'registered',
+    UNREGISTERED = 'unregistered'
+}
+
 /**
  * The GlobalHotkey module can register/unregister a global hotkeys.
  * @namespace
@@ -47,7 +52,10 @@ export default class GlobalHotkey extends EmitterBase {
      * @tutorial GlobalHotkey.unregisterAll
      */
     public async unregisterAll(): Promise<void> {
-        this.emitter.removeAllListeners();
+        this.emitter.eventNames()
+            .filter((name: string) => !(name === nonHotkeyEvents.REGISTERED || name === nonHotkeyEvents.UNREGISTERED))
+            .forEach((name: string) => this.emitter.removeAllListeners(name));
+
         await this.wire.sendAction(apiActions.UNREGISTER_ALL, {});
         return void 0;
     }

--- a/test/global-hotkey.test.ts
+++ b/test/global-hotkey.test.ts
@@ -155,4 +155,32 @@ describe('GlobalHotkey.', function() {
             assert.equal(err.message, 'Error: Failed to register Hotkey: CommandOrControl+X, already registered');
         }
     });
+
+    it('should raise unregister as we unregister all hotkeys', async() => {
+        const spy = sinon.spy();
+        const spy2 = sinon.spy();
+        await fin.GlobalHotkey.on('unregistered', spy2);
+        await fin.GlobalHotkey.register(hotkey, spy);
+        await fin.GlobalHotkey.unregisterAll();
+
+        assert.ok(spy2.calledOnce, 'Expected the unregistered event to be called at least once');
+    });
+
+    it('should raise register after we unregister all hotkeys',  function(done: any) {
+        async function test() {
+            const spy = sinon.spy();
+            const spy2 = sinon.spy();
+
+            await fin.GlobalHotkey.register(hotkey, spy);
+            await fin.GlobalHotkey.on('registered',  async (evt) => {
+                assert.deepStrictEqual(evt.hotkey, hotkey, 'Expected hotkey from event to match');
+                await fin.GlobalHotkey.removeAllListeners('unregistered');
+                done();
+            });
+            await fin.GlobalHotkey.unregisterAll();
+            await fin.GlobalHotkey.register(hotkey, spy2);
+        }
+
+        test();
+    });
 });


### PR DESCRIPTION
Fix a bug where unregisterAll would also remove event listeners for 'registered' and 'unregistered' events.

