### PR TITLE
RUN-4342 - Multi-runtime channels

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -76,6 +76,7 @@ export class EmitterBase extends Base {
     }
 
     protected registerEventListener = (listener: RuntimeEvent): Promise<void | Message<void>> => {
+        console.error('registerEList', JSON.stringify(listener));
         const key = createKey(listener);
         const refCount = this.wire.topicRefMap.get(key);
 
@@ -106,6 +107,8 @@ export class EmitterBase extends Base {
 
     public on(eventType: string, listener: (...args: any[]) => void): Promise<void> {
         this.emitter.on(eventType, listener);
+        console.error('on topic, eventtype,', this.topic, eventType);
+        console.error('this.id,', this.identity);
         return this.registerEventListener(Object.assign({}, this.identity, {
             type: eventType,
             topic: this.topic

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -76,7 +76,6 @@ export class EmitterBase extends Base {
     }
 
     protected registerEventListener = (listener: RuntimeEvent): Promise<void | Message<void>> => {
-        console.error('registerEList', JSON.stringify(listener));
         const key = createKey(listener);
         const refCount = this.wire.topicRefMap.get(key);
 
@@ -103,12 +102,12 @@ export class EmitterBase extends Base {
             }
             return Promise.resolve();
         }
+        // This will only be reached if unsubscribe from event that does not exist but do not want to error here
+        return Promise.resolve();
     }
 
     public on(eventType: string, listener: (...args: any[]) => void): Promise<void> {
         this.emitter.on(eventType, listener);
-        console.error('on topic, eventtype,', this.topic, eventType);
-        console.error('this.id,', this.identity);
         return this.registerEventListener(Object.assign({}, this.identity, {
             type: eventType,
             topic: this.topic

--- a/src/api/interappbus/channel/client.ts
+++ b/src/api/interappbus/channel/client.ts
@@ -2,7 +2,6 @@ import { ChannelBase, ProviderIdentity } from './channel';
 import Transport from '../../../transport/transport';
 
 export class ChannelClient extends ChannelBase {
-    public onChannelDisconnect: (f: () => void) => void;
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
         super(providerIdentity, send);
     }

--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -42,6 +42,13 @@ export class Channel extends EmitterBase {
         });
     }
 
+    public async onChannelDisconnect(listener: Function): Promise<void> {
+        return this.on('internal-disconnected', (payload) => {
+            const eventPayload = Object.assign(payload, {type: 'disconnected'});
+            listener(eventPayload);
+        });
+    }
+
     // DOCS - if want to send payload, put payload in options
     public async connect(options: Options): Promise<ChannelClient> {
         try {
@@ -59,7 +66,6 @@ export class Channel extends EmitterBase {
             this.channelMap.set(key, channel);
             return channel;
         } catch (e) {
-            // HOW TO ACTUALLY ERROR OUT???
             const shouldWait: boolean = Object.assign({ wait: true }, options).wait;
             const internalNackMessage = 'internal-nack';
             if (shouldWait && e.message === internalNackMessage) {
@@ -75,8 +81,7 @@ export class Channel extends EmitterBase {
                         }
                     });
                 });
-                await waitResponse;
-                return Promise.resolve(waitResponse);
+                return await waitResponse;
             } else if (e.message === internalNackMessage) {
                 throw new Error('No channel found');
             } else {

--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -36,14 +36,14 @@ export class Channel extends EmitterBase {
     }
 
     public async onChannelConnect(listener: Function): Promise<void> {
-        return this.on('internal-connected', (payload) => {
+        return this.on('connected', (payload) => {
             const eventPayload = Object.assign(payload, {type: 'connected'});
             listener(eventPayload);
         });
     }
 
     public async onChannelDisconnect(listener: Function): Promise<void> {
-        return this.on('internal-disconnected', (payload) => {
+        return this.on('disconnected', (payload) => {
             const eventPayload = Object.assign(payload, {type: 'disconnected'});
             listener(eventPayload);
         });
@@ -54,14 +54,6 @@ export class Channel extends EmitterBase {
         try {
             const { payload: { data: providerIdentity } } = await this.wire.sendAction('connect-to-channel', options);
             const channel = new ChannelClient(providerIdentity, this.wire.sendAction.bind(this.wire));
-            channel.onChannelDisconnect = (listener: () => void) => {
-                this.registerEventListener({
-                    topic: 'channel',
-                    type: 'disconnected',
-                    ...providerIdentity
-                });
-                this.on('disconnected', listener);
-            };
             const key = providerIdentity.channelId || providerIdentity.uuid;
             this.channelMap.set(key, channel);
             return channel;

--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -37,7 +37,11 @@ export class Channel extends EmitterBase {
 
     // FIX TYPES HERE!
     public async onChannelConnect(listener: Function): Promise<void> {
-        return this.on('connected/*', (payload) => listener(payload.data[0]));
+        console.error('here in on chann con real');
+        return this.on('connected/*', (payload) => {
+            console.error('made it into list', listener);
+            listener(payload.data[0]);
+    });
     }
 
     // DOCS - if want to send payload, put payload in options
@@ -64,15 +68,16 @@ export class Channel extends EmitterBase {
                 const { uuid } = options;
                 const waitResponse: Promise<ChannelClient> = new Promise(resolve => {
                     console.error('in wr', this.onChannelConnect);
-                    // this.onChannelConnect((channel: any) => {
-                    //     console.error('in channel connect', channel);
-                    //     if (channel.uuid === uuid) {
-                    //         this.connect(options).then(response => {
-                    //             resolve(response);
-                    //         });
-                    //     }
-                    // });
-                    this.onChannelConnect(console.log);
+                    try {
+                        this.onChannelConnect((channel: any) => {
+                            console.error('in channel connect', channel);
+                            if (channel.uuid === uuid) {
+                                this.connect(options).then(response => {
+                                    resolve(response);
+                                });
+                            }
+                        });
+                    } catch (e) {console.error('uhoh', e); }
                 });
                 console.error('right before waitRes');
                 await waitResponse;

--- a/src/transport/transport.ts
+++ b/src/transport/transport.ts
@@ -155,7 +155,6 @@ class Transport extends EventEmitter {
 
     // This method executes message handlers until the _one_ that handles the message (returns truthy) has run
     protected onmessage(data: Message<Payload>): void {
-        console.error('onmessage', JSON.stringify(data));
         for (const h of this.messageHandlers) {
             h.call(null, data);
         }

--- a/src/transport/transport.ts
+++ b/src/transport/transport.ts
@@ -139,7 +139,7 @@ class Transport extends EventEmitter {
     }
 
     public registerMessageHandler(handler: MessageHandler): void {
-        this.messageHandlers.push(handler);
+        this.messageHandlers.unshift(handler);
     }
 
     protected addWireListener(id: number, resolve: Function, reject: Function, uncorrelated: boolean): void {

--- a/src/transport/transport.ts
+++ b/src/transport/transport.ts
@@ -139,7 +139,7 @@ class Transport extends EventEmitter {
     }
 
     public registerMessageHandler(handler: MessageHandler): void {
-        this.messageHandlers.unshift(handler);
+        this.messageHandlers.push(handler);
     }
 
     protected addWireListener(id: number, resolve: Function, reject: Function, uncorrelated: boolean): void {

--- a/src/transport/transport.ts
+++ b/src/transport/transport.ts
@@ -155,7 +155,7 @@ class Transport extends EventEmitter {
 
     // This method executes message handlers until the _one_ that handles the message (returns truthy) has run
     protected onmessage(data: Message<Payload>): void {
-
+        console.error('onmessage', JSON.stringify(data));
         for (const h of this.messageHandlers) {
             h.call(null, data);
         }

--- a/test/multi-runtime-application.test.ts
+++ b/test/multi-runtime-application.test.ts
@@ -84,7 +84,7 @@ describe('Multi Runtime', function () {
                 const isRunning = await app.isRunning();
 
                 assert.equal(isRunning, true, 'Expected application to be running');
-                return await realApp.close().then();
+                return await realApp.close();
             });
         });
     });

--- a/test/multi-runtime-channel.test.ts
+++ b/test/multi-runtime-channel.test.ts
@@ -152,7 +152,6 @@ describe ('Multi Runtime Services', function() {
             async function test() {
                 const [fin, finA] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 const client = finA.InterApplicationBus.Channel.connect({uuid: 'channel-provider-test'});
-                fin.InterApplicationBus.Channel.onChannelConnect(console.log);
                 client.then(async (c) => {
                     console.error('here inn client');
                     c.register('multi-runtime-test', (r: string) => {

--- a/test/multi-runtime-channel.test.ts
+++ b/test/multi-runtime-channel.test.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 
 describe ('Multi Runtime Services', function() {
-    this.timeout(TEST_TIMEOUT / 4);
+    this.timeout(TEST_TIMEOUT / 3);
     const appConfig = JSON.parse(fs.readFileSync(path.resolve('test/app.json')).toString());
 
     beforeEach(async () => {
@@ -151,23 +151,19 @@ describe ('Multi Runtime Services', function() {
 
             async function test() {
                 const [fin, finA] = await Promise.all([launchAndConnect(), launchAndConnect()]);
-                const client = finA.InterApplicationBus.Channel.connect({uuid: 'channel-provider-test'});
-                client.then(async (c) => {
-                    console.error('here inn client');
+                finA.InterApplicationBus.Channel.connect({uuid: 'channel-provider-test'})
+                .then((c) => {
                     c.register('multi-runtime-test', (r: string) => {
                         assert.equal(r, 'return-mrt', 'wrong payload sent from service');
                         done();
                     });
-                    await delayPromise(1000);
                     c.dispatch('test').then(res => {
                         assert.equal(res, 'return-test', 'wrong return payload from service');
                     });
                 });
                 await delayPromise(2000);
-                console.error('here');
                 const service = await fin.Application.create(serviceConfig);
                 await service.run();
-                console.error('here');
             }
             test();
         });


### PR DESCRIPTION
See [Core PR](https://github.com/HadoukenIO/core/pull/508)

Moved pending channel connections into js-adapter.  
- If channel does not yet exist, core nacks back with interimNack message. Then we listen for connection event with correct UUID (later to be include name &/or channelName) and will resend the connect message -where it can be routed to correct runtime via normal mesh middleware.
- better handles lifecycle of request (if entity that made request closes, navigates, reloads etc.)
- better to implement multi-runtime channel connection with eventing / existing middleware

Had to fix some tests to make them all pass.  Added another multi-runtime test that was failing prior to these changes.

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b60f0a854b21953031f388d)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b60f20a54b21953031f3891)