### PR TITLE
RUN-4331 - Multiple channels per identity

### DIFF
--- a/html/client.html
+++ b/html/client.html
@@ -11,7 +11,7 @@
 <script>
     fin.desktop.main(async () => {
         fin.desktop.InterApplicationBus.subscribe("*", "start", async function(message, uuid, name) {
-            const client = await fin.InterApplicationBus.Channel.connect({uuid});
+            const client = await fin.InterApplicationBus.Channel.connect(message);
             client.register('multi-runtime-test', res => {
                 fin.desktop.InterApplicationBus.publish("multi-runtime-test-return", res);
             });

--- a/html/service.html
+++ b/html/service.html
@@ -10,7 +10,7 @@
 
 <script>
     fin.desktop.main(async () => {
-        const provider = await fin.InterApplicationBus.Channel.create('test-channel');
+        const provider = await fin.InterApplicationBus.Channel.create('mrtest');
         provider.register('test', (payload, id) => {
             provider.dispatch(id, 'multi-runtime-test', 'return-mrt');
             return 'return-test';

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -1,7 +1,7 @@
 import { ChannelBase, ProviderIdentity } from './channel';
 import Transport from '../../../transport/transport';
 
-export type ConnectionListener = (adapterIdentity: ProviderIdentity, connectionMessage?: any) => any;
+export type ConnectionListener = (providerIdentity: ProviderIdentity, connectionMessage?: any) => any;
 
 export class ChannelProvider extends ChannelBase {
     private connectListener: ConnectionListener;

--- a/test/external-channel.test.ts
+++ b/test/external-channel.test.ts
@@ -48,7 +48,7 @@ describe ('External Channel Provider', function() {
             async function test () {
                 const spy = sinon.spy();
                 const finA = await launchAndConnect();
-                const provider = await finA.InterApplicationBus.Channel.create('test');
+                const provider = await finA.InterApplicationBus.Channel.create('ext-test');
                 provider.register('test', () => {
                     spy();
                     return 'return-test';
@@ -65,7 +65,7 @@ describe ('External Channel Provider', function() {
                 };
                 await finA.InterApplicationBus.subscribe({uuid: 'channel-client-test'}, 'return', listener);
                 await delayPromise(DELAY_MS);
-                await finA.InterApplicationBus.publish('start', 'hi');
+                await finA.InterApplicationBus.publish('start', 'ext-test');
                 await delayPromise(DELAY_MS);
             }
             test();
@@ -95,8 +95,7 @@ describe ('External Channel Provider', function() {
                 const finA = await launchAndConnect();
                 const service = await finA.Application.create(serviceConfig);
                 await service.run();
-                const providerIdentity = {uuid: 'channel-provider-test', name: 'channel-provider-test'};
-                const client = await finA.InterApplicationBus.Channel.connect(providerIdentity);
+                const client = await finA.InterApplicationBus.Channel.connect('ext-test');
                 client.dispatch('test').then(res => {
                     assert(res === 'return-test');
                     done();

--- a/test/multi-runtime-channel.test.ts
+++ b/test/multi-runtime-channel.test.ts
@@ -46,7 +46,7 @@ describe ('Multi Runtime Channels', function() {
             async function test () {
                 const spy = sinon.spy();
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
-                const provider = await finB.InterApplicationBus.Channel.create();
+                const provider = await finB.InterApplicationBus.Channel.create('test');
                 provider.register('test', () => {
                     spy();
                     return 'return-test';
@@ -91,7 +91,7 @@ describe ('Multi Runtime Channels', function() {
                 const service = await finA.Application.create(serviceConfig);
                 await service.run();
                 await delayPromise(DELAY_MS);
-                const client = await finB.InterApplicationBus.Channel.connect({uuid: 'channel-provider-test'});
+                const client = await finB.InterApplicationBus.Channel.connect('test');
                 client.register('multi-runtime-test', (r: string) => {
                     assert.equal(r, 'return-mrt', 'wrong payload sent from service');
                     done();
@@ -156,13 +156,13 @@ describe ('Multi Runtime Channels', function() {
 
             async function test() {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
-                finB.InterApplicationBus.Channel.connect({uuid: 'channel-provider-mrtest'})
+                finB.InterApplicationBus.Channel.connect('mrtest')
                 .then((c) => {
                     c.register('multi-runtime-test', (r: string) => {
                         assert.equal(r, 'return-mrt', 'wrong payload sent from service');
                         done();
                     });
-                    c.dispatch('test').then(res => {
+                    c.dispatch('test').then((res: any) => {
                         assert.equal(res, 'return-test', 'wrong return payload from service');
                     });
                 });


### PR DESCRIPTION
Ability to create multiple channels for a single application.  Must connect to channel by UUID, and if you want multiple channels per UUID, then you would need a channelName.  

[Core PR](https://github.com/HadoukenIO/core/pull/524)

Four new testrunner tests:
[one](https://testing-dashboard.openfin.co/#/app/tests/5b7599ab6107b45e6d1eba2b/edit)
[two](https://testing-dashboard.openfin.co/#/app/tests/5b759e5a6107b45e6d1eba32/edit)
[three](https://testing-dashboard.openfin.co/#/app/tests/5b75d86c6107b45e6d1eba3e/edit)
[four](https://testing-dashboard.openfin.co/#/app/tests/5b75d9e56107b45e6d1eba3f/edit)

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b75bf886107b45e6d1eba37)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b75c0af6107b45e6d1eba38)

Failed onDisconnection test to be fixed in [this JIRA](https://appoji.jira.com/browse/RUN-4330)
Failed [win7 test](https://testing-dashboard.openfin.co/#/app/tests/5b52441854b21953031f378b/edit) on app.getinfo due to hosting error, reran and passed.