### PR TITLE
Core builds should be optional.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function (grunt) {
     const remote = grunt.option('remote');
     const rvmDir = grunt.option('rvmDir');
     const target = grunt.option('target');
+    const shouldBuildCore = grunt.option('build-core');
     const uuid = 'testapp';
     const args = '--enable-multi-runtime --debug=5858';
     process.env.OF_VER = version;
@@ -180,6 +181,11 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask('core', function () {
+        if (!shouldBuildCore) {
+            grunt.log.ok('skipping core build task');
+            return;
+        }
+
         if (version) {
             let done = this.async();
             resolveRuntimeVersion(version).then(v => {

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ npm test -- --ver=alpha --invert --grep="System"
 ## Test with core
 
 ```bash
-npm run core -- --core=~/core
+npm test -- --ver=alpha --build-core --core=~/core
 ```
 
 or without specifying the core path (core will be cloned from GH into `core` directory):
 
 ```bash
-npm run core
+npm test -- --ver=alpha --build-core
 ```
 
 ## Repl

--- a/README.md
+++ b/README.md
@@ -103,12 +103,6 @@ npm run build
 npm test -- --ver=alpha
 ```
 
-Specifying the core path
-
-```bash
-npm test -- --ver=alpha --core=~/core
-```
-
 Only executing tests that pattern match "Application"
 
 ```bash


### PR DESCRIPTION
the `test` task automatically runs the `core` task, this is not always what you need. 

Made the `core` task opt in by argument.