### PR TITLE
RUN-4331 - Multiple channels by channelName

### DIFF
--- a/html/client.html
+++ b/html/client.html
@@ -11,7 +11,7 @@
 <script>
     fin.desktop.main(async () => {
         fin.desktop.InterApplicationBus.subscribe("*", "start", async function(message, uuid, name) {
-            const client = await fin.InterApplicationBus.Channel.connect({uuid});
+            const client = await fin.InterApplicationBus.Channel.connect(message);
             client.register('multi-runtime-test', res => {
                 fin.desktop.InterApplicationBus.publish("multi-runtime-test-return", res);
             });

--- a/html/service.html
+++ b/html/service.html
@@ -10,7 +10,7 @@
 
 <script>
     fin.desktop.main(async () => {
-        const provider = await fin.InterApplicationBus.Channel.create('mrtest');
+        const provider = await fin.InterApplicationBus.Channel.create('test');
         provider.register('test', (payload, id) => {
             provider.dispatch(id, 'multi-runtime-test', 'return-mrt');
             return 'return-test';

--- a/html/service.html
+++ b/html/service.html
@@ -10,7 +10,7 @@
 
 <script>
     fin.desktop.main(async () => {
-        const provider = await fin.InterApplicationBus.Channel.create('test-channel');
+        const provider = await fin.InterApplicationBus.Channel.create('mrtest');
         provider.register('test', (payload, id) => {
             provider.dispatch(id, 'multi-runtime-test', 'return-mrt');
             return 'return-test';

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -90,10 +90,10 @@ export class EmitterBase extends Base {
             const newRefCount = refCount - 1;
             if (newRefCount === 0) {
                 await this.wire.sendAction('unsubscribe-to-desktop-event', runtimeEvent);
-                if (emitter.eventNames().length === 0) {
-                    this.wire.eventAggregator.delete(this.emitterAccessor);
-                    return;
-                }
+                // if (Object.keys(this.getEmitter()._events).length === 0) {
+                //     this.wire.eventAggregator.delete(this.emitterAccessor);
+                //     return;
+                // }
             }
             return emitter;
         }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -90,10 +90,11 @@ export class EmitterBase extends Base {
             const newRefCount = refCount - 1;
             if (newRefCount === 0) {
                 await this.wire.sendAction('unsubscribe-to-desktop-event', runtimeEvent);
-                // if (Object.keys(this.getEmitter()._events).length === 0) {
-                //     this.wire.eventAggregator.delete(this.emitterAccessor);
-                //     return;
-                // }
+                // TO DO: FIX - This was erroring out saying eventNames is not a function.
+                if (emitter.eventNames && emitter.eventNames().length === 0) {
+                    this.wire.eventAggregator.delete(this.emitterAccessor);
+                    return;
+                }
             }
             return emitter;
         }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -90,7 +90,6 @@ export class EmitterBase extends Base {
             const newRefCount = refCount - 1;
             if (newRefCount === 0) {
                 await this.wire.sendAction('unsubscribe-to-desktop-event', runtimeEvent);
-                // TO DO: FIX - This was erroring out saying eventNames is not a function.
                 if (emitter.eventNames && emitter.eventNames().length === 0) {
                     this.wire.eventAggregator.delete(this.emitterAccessor);
                     return;

--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -78,7 +78,7 @@ export class Channel extends EmitterBase {
         } catch (e) {
             const shouldWait: boolean = Object.assign({ wait: true }, opts).wait;
             const internalNackMessage = 'internal-nack';
-            if (shouldWait && e.message === internalNackMessage) {
+            if (shouldWait && e.message.includes(internalNackMessage)) {
                 console.warn(`Channel not found for channelName: ${channelName}, waiting for channel creation.`);
                 return await waitResponse;
             } else if (e.message === internalNackMessage) {

--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -5,11 +5,8 @@ import { EmitterBase } from '../../base';
 import Transport, { Message, Payload } from '../../../transport/transport';
 import { ProviderIdentity } from './channel';
 
-export interface Options {
-    uuid: string;
-    channelName: string;
+export interface ConnectOptions {
     wait?: boolean;
-    name?: string;
     payload?: any;
 }
 
@@ -45,7 +42,7 @@ export class Channel extends EmitterBase {
         await this.on('disconnected', listener);
     }
 
-    public async connect(channelName: string, options?: Options): Promise<ChannelClient> {
+    public async connect(channelName: string, options?: ConnectOptions): Promise<ChannelClient> {
         if (!channelName || typeof channelName !== 'string') {
             throw new Error('Please provide a channelName string to connect to a channel.');
         }

--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -75,7 +75,7 @@ export class Channel extends EmitterBase {
         } catch (e) {
             const shouldWait: boolean = Object.assign({ wait: true }, opts).wait;
             const internalNackMessage = 'internal-nack';
-            if (shouldWait && e.message.includes(internalNackMessage)) {
+            if (shouldWait && e.message && e.message.includes(internalNackMessage)) {
                 console.warn(`Channel not found for channelName: ${channelName}, waiting for channel creation.`);
                 return await waitResponse;
             } else if (e.message === internalNackMessage) {

--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -7,7 +7,7 @@ import { ProviderIdentity } from './channel';
 
 export interface Options {
     uuid: string;
-    channelName?: string;
+    channelName: string;
     wait?: boolean;
     name?: string;
     payload?: any;

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -1,7 +1,7 @@
 import { ChannelBase, ProviderIdentity } from './channel';
 import Transport from '../../../transport/transport';
 
-export type ConnectionListener = (adapterIdentity: ProviderIdentity, connectionMessage?: any) => any;
+export type ConnectionListener = (providerIdentity: ProviderIdentity, connectionMessage?: any) => any;
 
 export class ChannelProvider extends ChannelBase {
     private connectListener: ConnectionListener;

--- a/test/external-channel.test.ts
+++ b/test/external-channel.test.ts
@@ -48,7 +48,7 @@ describe ('External Channel Provider', function() {
             async function test () {
                 const spy = sinon.spy();
                 const finA = await launchAndConnect();
-                const provider = await finA.InterApplicationBus.Channel.create('test');
+                const provider = await finA.InterApplicationBus.Channel.create('ext-test');
                 provider.register('test', () => {
                     spy();
                     return 'return-test';
@@ -65,7 +65,7 @@ describe ('External Channel Provider', function() {
                 };
                 await finA.InterApplicationBus.subscribe({uuid: 'channel-client-test'}, 'return', listener);
                 await delayPromise(DELAY_MS);
-                await finA.InterApplicationBus.publish('start', 'hi');
+                await finA.InterApplicationBus.publish('start', 'ext-test');
                 await delayPromise(DELAY_MS);
             }
             test();
@@ -95,8 +95,7 @@ describe ('External Channel Provider', function() {
                 const finA = await launchAndConnect();
                 const service = await finA.Application.create(serviceConfig);
                 await service.run();
-                const providerIdentity = {uuid: 'channel-provider-test', name: 'channel-provider-test'};
-                const client = await finA.InterApplicationBus.Channel.connect(providerIdentity);
+                const client = await finA.InterApplicationBus.Channel.connect('ext-test');
                 client.dispatch('test').then(res => {
                     assert(res === 'return-test');
                     done();

--- a/test/external-channel.test.ts
+++ b/test/external-channel.test.ts
@@ -48,12 +48,13 @@ describe ('External Channel Provider', function() {
             async function test () {
                 const spy = sinon.spy();
                 const finA = await launchAndConnect();
-                const provider = await finA.InterApplicationBus.Channel.create('ext-test');
+                const provider = await finA.InterApplicationBus.Channel.create('exttest');
                 provider.register('test', () => {
                     spy();
                     return 'return-test';
                 });
                 provider.onConnection(c => {
+                    console.error('connected!');
                     spy();
                 });
                 const client = await finA.Application.create(clientConfig);
@@ -65,7 +66,7 @@ describe ('External Channel Provider', function() {
                 };
                 await finA.InterApplicationBus.subscribe({uuid: 'channel-client-test'}, 'return', listener);
                 await delayPromise(DELAY_MS);
-                await finA.InterApplicationBus.publish('start', 'ext-test');
+                await finA.InterApplicationBus.publish('start', 'exttest');
                 await delayPromise(DELAY_MS);
             }
             test();
@@ -95,7 +96,7 @@ describe ('External Channel Provider', function() {
                 const finA = await launchAndConnect();
                 const service = await finA.Application.create(serviceConfig);
                 await service.run();
-                const client = await finA.InterApplicationBus.Channel.connect('ext-test');
+                const client = await finA.InterApplicationBus.Channel.connect('test');
                 client.dispatch('test').then(res => {
                     assert(res === 'return-test');
                     done();

--- a/test/multi-runtime-channel.test.ts
+++ b/test/multi-runtime-channel.test.ts
@@ -46,7 +46,7 @@ describe ('Multi Runtime Channels', function() {
             async function test () {
                 const spy = sinon.spy();
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
-                const provider = await finB.InterApplicationBus.Channel.create();
+                const provider = await finB.InterApplicationBus.Channel.create('test');
                 provider.register('test', () => {
                     spy();
                     return 'return-test';
@@ -91,7 +91,7 @@ describe ('Multi Runtime Channels', function() {
                 const service = await finA.Application.create(serviceConfig);
                 await service.run();
                 await delayPromise(DELAY_MS);
-                const client = await finB.InterApplicationBus.Channel.connect({uuid: 'channel-provider-test'});
+                const client = await finB.InterApplicationBus.Channel.connect('test');
                 client.register('multi-runtime-test', (r: string) => {
                     assert.equal(r, 'return-mrt', 'wrong payload sent from service');
                     done();
@@ -156,13 +156,13 @@ describe ('Multi Runtime Channels', function() {
 
             async function test() {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
-                finB.InterApplicationBus.Channel.connect({uuid: 'channel-provider-mrtest'})
+                finB.InterApplicationBus.Channel.connect('mrtest')
                 .then((c) => {
                     c.register('multi-runtime-test', (r: string) => {
                         assert.equal(r, 'return-mrt', 'wrong payload sent from service');
                         done();
                     });
-                    c.dispatch('test').then(res => {
+                    c.dispatch('test').then((res: any) => {
                         assert.equal(res, 'return-test', 'wrong return payload from service');
                     });
                 });

--- a/test/multi-runtime-channel.test.ts
+++ b/test/multi-runtime-channel.test.ts
@@ -46,7 +46,7 @@ describe ('Multi Runtime Channels', function() {
             async function test () {
                 const spy = sinon.spy();
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
-                const provider = await finB.InterApplicationBus.Channel.create('test');
+                const provider = await finB.InterApplicationBus.Channel.create('test-ext-provider');
                 provider.register('test', () => {
                     spy();
                     return 'return-test';
@@ -62,7 +62,7 @@ describe ('Multi Runtime Channels', function() {
                     assert.equal(msg, 'return-test');
                     done();
                 });
-                await finB.InterApplicationBus.publish('start', 'hi');
+                await finB.InterApplicationBus.publish('start', 'test-ext-provider');
             }
             test().catch(() => cleanOpenRuntimes());
         });
@@ -156,7 +156,7 @@ describe ('Multi Runtime Channels', function() {
 
             async function test() {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
-                finB.InterApplicationBus.Channel.connect('mrtest')
+                finB.InterApplicationBus.Channel.connect('test')
                 .then((c) => {
                     c.register('multi-runtime-test', (r: string) => {
                         assert.equal(r, 'return-mrt', 'wrong payload sent from service');

--- a/test/multi-runtime-channel.test.ts
+++ b/test/multi-runtime-channel.test.ts
@@ -74,7 +74,7 @@ describe ('Multi Runtime Channels', function() {
             const url = appConfig.startup_app.url;
             const newUrl = url.slice(0, url.lastIndexOf('/')) + '/service.html';
 
-            const serviceConfig = {
+            const providerConfig = {
                 'name': 'channel-provider-test',
                 'url': newUrl,
                 'uuid': 'channel-provider-test',
@@ -88,12 +88,13 @@ describe ('Multi Runtime Channels', function() {
 
             async function test() {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
-                const service = await finA.Application.create(serviceConfig);
-                await service.run();
+                const provider = await finA.Application.create(providerConfig);
+                await provider.run();
                 await delayPromise(DELAY_MS);
                 const client = await finB.InterApplicationBus.Channel.connect('test');
+                console.error('client', client);
                 client.register('multi-runtime-test', (r: string) => {
-                    assert.equal(r, 'return-mrt', 'wrong payload sent from service');
+                    assert.equal(r, 'return-mrt', 'wrong payload sent from provider');
                     done();
                 });
                 client.dispatch('test').then(res => {
@@ -126,7 +127,7 @@ describe ('Multi Runtime Channels', function() {
                 const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
                 const service = await finA.Application.create(serviceConfig);
                 await service.run();
-                await finB.InterApplicationBus.Channel.create('test-channel-multi-runtime');
+                await finB.InterApplicationBus.Channel.create('getAllChannels-multi-runtime');
                 await delayPromise(DELAY_MS * 3);
                 const allChannels = await fin.InterApplicationBus.Channel.getAllChannels();
                 assert.equal(allChannels.length, 2, `expected 2 channels in allChannels: ${JSON.stringify(allChannels)}`);

--- a/test/multi-runtime-channel.test.ts
+++ b/test/multi-runtime-channel.test.ts
@@ -92,7 +92,6 @@ describe ('Multi Runtime Channels', function() {
                 await provider.run();
                 await delayPromise(DELAY_MS);
                 const client = await finB.InterApplicationBus.Channel.connect('test');
-                console.error('client', client);
                 client.register('multi-runtime-test', (r: string) => {
                     assert.equal(r, 'return-mrt', 'wrong payload sent from provider');
                     done();
@@ -170,6 +169,26 @@ describe ('Multi Runtime Channels', function() {
                 await delayPromise(DELAY_MS * 2);
                 const service = await finA.Application.create(serviceConfig);
                 await service.run();
+            }
+            test().catch(() => cleanOpenRuntimes());
+        });
+    });
+
+    describe('Multi Runtime two channel with same name', function () {
+
+        it('Should not be able to create two channels with the same name', function(done: any) {
+            async function test() {
+                const [finA, finB] = await Promise.all([launchAndConnect(), launchAndConnect()]);
+                await delayPromise(DELAY_MS);
+                try {
+                    await finA.InterApplicationBus.Channel.create('mr-channel-name-test');
+                    await finB.InterApplicationBus.Channel.create('mr-channel-name-test');
+                } catch {
+                    assert(true, 'no error on second channel creation');
+                    done();
+                }
+                assert(false, 'no error on second channel creation');
+                done();
             }
             test().catch(() => cleanOpenRuntimes());
         });


### PR DESCRIPTION
Ability to create multiple channels for a single application.  Must use a channelName when you create a channel and you connect to channel by a channelName as well.  ChannelNames will be unique and creation will fail if you provide a name that is not unique.

[Core PR](https://github.com/HadoukenIO/core/pull/524)

Updated all channel related tests, plus there are six new testrunner tests and the additional js-adapter test in the code change:
[one](https://testing-dashboard.openfin.co/#/app/tests/5b7599ab6107b45e6d1eba2b/edit)
[two](https://testing-dashboard.openfin.co/#/app/tests/5b759e5a6107b45e6d1eba32/edit)
[three](https://testing-dashboard.openfin.co/#/app/tests/5b75d86c6107b45e6d1eba3e/edit)
[four](https://testing-dashboard.openfin.co/#/app/tests/5b75d9e56107b45e6d1eba3f/edit)
[five](https://testing-dashboard.openfin.co/#/app/tests/5b7ecb7c6107b45e6d1ebb45/edit)
[six](https://testing-dashboard.openfin.co/#/app/tests/5b7eca916107b45e6d1ebb44/edit)

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b8056906107b45e6d1ebb6b)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b804ed76107b45e6d1ebb68)