### PR TITLE
RUN-4494: Deprecate System.getDeviceId() for System.getMachineId()

### DIFF
--- a/src/api/system/system.ts
+++ b/src/api/system/system.ts
@@ -280,14 +280,11 @@ export default class System extends EmitterBase {
         return this.wire.sendAction('get-crash-reporter-state').then(({ payload }) => payload.data);
     }
 
-    /**
-     * Returns a unique identifier (UUID) for the machine (SHA256 hash of the system's MAC address).
-     * This call will return the same value on subsequent calls on the same machine(host).
-     * The values will be different on different machines, and should be considered globally unique.
-     * @return {Promise.<string>}
-     * @tutorial System.getDeviceId
+    /* <-- Note the one asterisk to hide from jsdoc because we don't want to publish this method anymore.
+     * @deprecated Use {@link System.getMachineId} instead.
      */
     public getDeviceId(): Promise<string> {
+        console.warn('Function is deprecated; use getMachineId instead.');
         return this.wire.sendAction('get-device-id').then(({ payload }) => payload.data);
     }
 

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -128,11 +128,6 @@ describe('System.', function () {
         }));
     });
 
-    describe('getDeviceId()', () => {
-
-        it('Fulfilled', () => fin.System.getDeviceId().then(() => assert(true)));
-    });
-
     describe('getDeviceUserId()', () => {
 
         it('Fulfilled', () => fin.System.getDeviceUserId().then(id => {

--- a/tutorials/System.getDeviceId.md
+++ b/tutorials/System.getDeviceId.md
@@ -1,8 +1,0 @@
-Returns a unique identifier (UUID) for the machine (SHA256 hash of the system's MAC address).
-This call will return the same value on subsequent calls on the same machine(host).
-The values will be different on different machines, and should be considered globally unique.
-
-# Example
-```js
-fin.System.getDeviceId().then(id => console.log(id)).catch(err => console.log(err));
-```


### PR DESCRIPTION
This won't make sense without #174 