### PR TITLE
RUN-2315 added support for taking a snapshot of an area in a window

### DIFF
--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -81,6 +81,21 @@ export interface FrameInfo {
     parent?: Identity;
 }
 
+export interface Area {
+    height: number;
+    width: number;
+    x: number;
+    y: number;
+}
+
+/**
+ * @typedef { Object } Area
+ * @property { number } height Area's height
+ * @property { number } width Area's width
+ * @property { number } x X coordinate of area's starting point
+ * @property { number } y Y coordinate of area's starting point
+ */
+
 /**
  * @typedef {object} Transition
  * @property {Opacity} opacity - The Opacity transition
@@ -797,12 +812,16 @@ export class _Window extends EmitterBase {
     }
 
     /**
-     * Gets a base64 encoded PNG snapshot of the window.
+     * Gets a base64 encoded PNG snapshot of the window or just part a of it.
+     * @param { Area } [area] The area of the window to be captured.
+     * Omitting it will capture the whole visible window.
      * @return {Promise.<string>}
      * @tutorial Window.getSnapshot
      */
-    public getSnapshot(): Promise<string> {
-        return this.wire.sendAction('get-window-snapshot', this.identity).then(({ payload }) => payload.data);
+    public async getSnapshot(area?: Area): Promise<string> {
+        const req = Object.assign({}, this.identity, { area });
+        const res = await this.wire.sendAction('get-window-snapshot', req);
+        return res.payload.data;
     }
 
     /**

--- a/tutorials/Window.getSnapshot.md
+++ b/tutorials/Window.getSnapshot.md
@@ -2,17 +2,19 @@ Gets a base64 encoded PNG snapshot of the window
 
 # Example
 ```js
-async function takeWindowSnapShot() {
-    const app = await fin.Application.create({
-        name: 'myApp',
-        uuid: 'app-1',
-        url: 'https://www.openfin.co',
-        autoShow: true
-    });
-    await app.run();
-    const win = await app.getWindow();
-    return await win.getSnapshot();
-}
+(async () => {
+    const wnd = await fin.Window.getCurrent();
 
-takeWindowSnapShot().then(snapShot => console.log(snapShot)).catch(err => console.log(err));
+    // Snapshot of a full visible window
+    console.log(await wnd.getSnapshot());
+
+    // Snapshot of a defined visible area of the window
+    const area = {
+        height: 100,
+        width: 100,
+        x: 10,
+        y: 10,
+    };
+    console.log(await wnd.getSnapshot(area));
+})();
 ```


### PR DESCRIPTION
ℹ️ **About**
This and related PRs add support for taking snapshots of an area in a window.

🔗 All linked PRs
1\. [core PR](https://github.com/HadoukenIO/core/pull/561)
2\. [javascript-adapter PR](https://github.com/openfin/javascript-adapter/pull/500)
3\. [js-adapter PR](https://github.com/HadoukenIO/js-adapter/pull/188)

➕ **New automated tests**
1\. [window.getSnapshot (specified area)](https://testing-dashboard.openfin.co/#/app/tests/5ba1497ad6d66a0ddf8e7253/edit)
2\. [window.getSnapshot (specified area) (V2 API)](https://testing-dashboard.openfin.co/#/app/tests/5baa700ecb360141a7dfcf5f/edit)

🚥 **Test results**
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5baa75bbcb360141a7dfcf65)
✅ Node test results
![screen shot 2018-09-25 at 12 53 56 pm](https://user-images.githubusercontent.com/5790216/46083329-389acd80-c16f-11e8-971c-1f7fbc90d45c.png)
