### PR TITLE
RUN-4443 - Channel Lifecycle / onDisconnection

### DIFF
--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -16,7 +16,7 @@ export interface ChannelPayload {
 export interface ChannelMessage extends Message<any> {
   senderIdentity: Identity;
   ackToSender: any;
-  providerIdentity: Identity;
+  providerIdentity: ProviderIdentity;
   connectAction: boolean;
 }
 
@@ -94,6 +94,14 @@ export class Channel extends EmitterBase {
         const channel = new ChannelProvider(providerIdentity, this.wire.sendAction.bind(this.wire));
         const key = providerIdentity.channelId;
         this.channelMap.set(key, channel);
+        this.on('client-disconnected', (eventPayload: ProviderIdentity) => {
+            if (eventPayload.channelName === channelName) {
+                channel.connections = channel.connections.filter(identity => {
+                    return identity.uuid !== eventPayload.uuid || identity.name !== eventPayload.name;
+                });
+                channel.disconnectListener(eventPayload);
+            }
+        });
         return channel;
     }
     public onmessage = (msg: ChannelMessage) => {

--- a/src/api/interappbus/channel/index.ts
+++ b/src/api/interappbus/channel/index.ts
@@ -100,6 +100,7 @@ export class Channel extends EmitterBase<ChannelEvents> {
                 channel.connections = channel.connections.filter(identity => {
                     return identity.uuid !== eventPayload.uuid || identity.name !== eventPayload.name;
                 });
+                //@ts-ignore use of private property
                 channel.disconnectListener(eventPayload);
             }
         });

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -5,8 +5,8 @@ import { Identity } from '../../../main';
 export type ConnectionListener = (identity: Identity, connectionMessage?: any) => any;
 
 export class ChannelProvider extends ChannelBase {
-    private connectListener: ConnectionListener;
-    private disconnectListener: ConnectionListener;
+    public connectListener: ConnectionListener;
+    public disconnectListener: ConnectionListener;
     public connections: Identity[];
 
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {
@@ -22,6 +22,7 @@ export class ChannelProvider extends ChannelBase {
 
     public async processConnection(senderId: Identity, payload: any) {
         this.connections.push(senderId);
+
         return this.connectListener(senderId, payload);
     }
 
@@ -31,6 +32,10 @@ export class ChannelProvider extends ChannelBase {
 
     public onConnection(listener: ConnectionListener): void {
         this.connectListener = listener;
+    }
+
+    public onDisconnection(listener: ConnectionListener): void {
+        this.disconnectListener = listener;
     }
 
 }

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -22,7 +22,6 @@ export class ChannelProvider extends ChannelBase {
 
     public async processConnection(senderId: Identity, payload: any) {
         this.connections.push(senderId);
-
         return this.connectListener(senderId, payload);
     }
 

--- a/src/api/interappbus/channel/provider.ts
+++ b/src/api/interappbus/channel/provider.ts
@@ -5,8 +5,8 @@ import { Identity } from '../../../main';
 export type ConnectionListener = (identity: Identity, connectionMessage?: any) => any;
 
 export class ChannelProvider extends ChannelBase {
-    public connectListener: ConnectionListener;
-    public disconnectListener: ConnectionListener;
+    private connectListener: ConnectionListener;
+    private disconnectListener: ConnectionListener;
     public connections: Identity[];
 
     constructor(providerIdentity: ProviderIdentity, send: Transport['sendAction']) {


### PR DESCRIPTION
Adding onDisconnection and cleaning up channel.connections on a disconnect.

[new testrunner](https://testing-dashboard.openfin.co/#/app/tests/5b56102154b21953031f37a7/edit)

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bb3e9cecb360141a7dfcffe)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bb3eafdcb360141a7dfd000)