### PR TITLE
RUN-4535 getGroup returns wrong Window

### DIFF
--- a/test/multi-runtime-utils.ts
+++ b/test/multi-runtime-utils.ts
@@ -5,7 +5,7 @@ import * as rimraf from 'rimraf';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ChildProcess from 'child_process';
-import { connect as rawConnect, Fin } from '../src/main';
+import { connect as rawConnect, Fin, Identity } from '../src/main';
 import { resolveDir, first } from '../src/launcher/util';
 import { serial, promiseMap } from '../src/util/promises';
 import { delayPromise } from './delay-promise';
@@ -239,3 +239,5 @@ export async function cleanOpenRuntimes(): Promise<void> {
 }
 
 export const getRuntimeProcessInfo = (fin: Fin) => first(runtimes, x => x.fin === fin);
+
+export const isSameIdentity = (id1: Identity, id2: Identity) => id1.name === id2.name && id1.uuid === id2.uuid;

--- a/test/window.test.ts
+++ b/test/window.test.ts
@@ -2,7 +2,7 @@ import { conn } from './connect';
 import * as assert from 'assert';
 import { connect as rawConnect, Fin, Application, Window } from '../src/main';
 import { delayPromise } from './delay-promise';
-import { cleanOpenRuntimes } from './multi-runtime-utils';
+import { cleanOpenRuntimes, isSameIdentity } from './multi-runtime-utils';
 import { _Window } from '../src/api/window/window';
 
 describe('Window.', function() {
@@ -197,12 +197,14 @@ describe('Window.', function() {
         it('Fulfilled', () => testWindow.joinGroup(app2Win).then(() => testWindow.getGroup()
             .then(group => {
                 assert(group.length === 2);
-                assert(group[0].identity.uuid !== group[1].identity.uuid);
+                const ids = group.map(w => w.identity);
+                assert(ids.some(id => isSameIdentity(testWindow.identity, id)));
+                assert(ids.some(id => isSameIdentity(app2Win.identity, id)));
+
             })));
     });
 
     describe('getGroup()', () => {
-
         it('Fulfilled', () => testWindow.getGroup().then(data => assert(data instanceof Array,
             `Expected ${typeof (data)} to be an instance of Array`)));
     });


### PR DESCRIPTION
This seems to have been fixed already. Added a test to better catch failures.