### PR TITLE
RUN-4712 Add API to associate app log with custom username

### DIFF
--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -341,6 +341,17 @@ export class Application extends EmitterBase<ApplicationEvents> {
     }
 
     /**
+     * Sets a username to correlate with App Log Management.
+     * @param { string } userName Username to correlate with App's Log.
+     * @return {Promise.<void>}
+     */
+    public async setAppLogUsername(userName: string): Promise<void> {
+        await this.wire.sendAction('set-app-log-username', Object.assign({}, this.identity, {
+            data: userName
+        }));
+    }
+
+    /**
      * @summary Retrieves information about the system tray.
      * @desc The only information currently returned is the position and dimensions.
      * @return {Promise.<TrayInfo>}

--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -342,11 +342,11 @@ export class Application extends EmitterBase<ApplicationEvents> {
 
     /**
      * Sets a username to correlate with App Log Management.
-     * @param { string } userName Username to correlate with App's Log.
+     * @param { string } username Username to correlate with App's Log.
      * @return {Promise.<void>}
      */
-    public async setAppLogUsername(userName: string): Promise<void> {
-        await this.wire.sendAction('set-app-log-username', Object.assign({data: userName}, this.identity));
+    public async setAppLogUsername(username: string): Promise<void> {
+        await this.wire.sendAction('set-app-log-username', Object.assign({data: username}, this.identity));
     }
 
     /**

--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -346,9 +346,7 @@ export class Application extends EmitterBase<ApplicationEvents> {
      * @return {Promise.<void>}
      */
     public async setAppLogUsername(userName: string): Promise<void> {
-        await this.wire.sendAction('set-app-log-username', Object.assign({}, this.identity, {
-            data: userName
-        }));
+        await this.wire.sendAction('set-app-log-username', Object.assign({data: userName}, this.identity));
     }
 
     /**

--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -344,6 +344,7 @@ export class Application extends EmitterBase<ApplicationEvents> {
      * Sets a username to correlate with App Log Management.
      * @param { string } username Username to correlate with App's Log.
      * @return {Promise.<void>}
+     * @tutorial Application.setAppLogUsername
      */
     public async setAppLogUsername(username: string): Promise<void> {
         await this.wire.sendAction('set-app-log-username', Object.assign({data: username}, this.identity));

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -184,6 +184,10 @@ describe('Application.', function() {
         });
     });
 
+    describe.skip('setAppLogUsername()', () => {
+        it('Fulfilled', () => testApp.setAppLogUsername('mockUser').then(() => assert(true)));
+    });
+
     describe.skip('setShortcuts()', () => {
         // need to create an application using manifest url
         let localApp: Application;

--- a/tutorials/Application.setAppLogUsername.md
+++ b/tutorials/Application.setAppLogUsername.md
@@ -1,0 +1,12 @@
+Sets a username that correlates the application's log with the application log manager.
+
+### Example
+```js
+async function setAppLogUser() {
+    const app = await fin.Application.getCurrent();
+    return await app.setAppLogUsername('username');
+}
+
+setAppLogUser().then(() => console.log('Success')).catch(err => console.log(err));
+
+```


### PR DESCRIPTION
Added a Core API with (action: "application-log-username"). Sends a message over the RVM bus that updates App Log username when uploaded.

Ex)
var app = fin.Application.getCurrent();
app.then(a => a.setAppLogUsername('test-username')).then( ()=>console.log('success'));