### PR TITLE
RUN-4730 listener callback not implemented in launchExternalProcess

### DIFF
--- a/src/api/system/system.ts
+++ b/src/api/system/system.ts
@@ -12,7 +12,8 @@ import { RVMInfo } from './rvm';
 import { RuntimeInfo } from './runtime-info';
 import { Entity, EntityInfo } from './entity';
 import { HostSpecs } from './host-specs';
-import { ExternalProcessRequestType , TerminateExternalRequestType, ExternalConnection, ExitCode, ExternalProcessInfo } from './external-process';
+import { ExternalProcessRequestType , TerminateExternalRequestType, ExternalConnection, ExitCode,
+    ExternalProcessInfo } from './external-process';
 import Transport from '../../transport/transport';
 import { CookieInfo, CookieOption } from './cookie';
 import { RegistryInfo } from './registry-info';

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -2,6 +2,7 @@ import { conn } from './connect';
 import { Fin } from '../src/main';
 import * as assert from 'assert';
 import { cleanOpenRuntimes } from './multi-runtime-utils';
+import { ExternalProcessRequestType, ExitCode } from '../src/api/system/external-process';
 
 describe('System.', function () {
     let fin: Fin;
@@ -207,19 +208,21 @@ describe('System.', function () {
         }));
     });
 
-    describe.skip('launchExternalProcess()', () => {
-        const processOptions = {
-            path: 'notepad',
-            arguments: '',
-            listener: (code: any) => { code = 'a'; }
-        };
-
+    describe('launchExternalProcess()', () => {
         it('Fulfilled', (done) => {
-            fin.System.launchExternalProcess(processOptions)
-                .then(() => {
-                    assert(true);
-                    return done();
-                });
+            const processOptions: ExternalProcessRequestType = {
+                path: 'notepad',
+                arguments: '',
+                listener: (result: ExitCode) => {
+                    assert(result.topic === 'exited', 'Expected topic is "exited"');
+                    assert(result.exitCode === 0);
+                    done();
+                }
+            };
+
+            fin.System.launchExternalProcess(processOptions).then(identity => {
+                fin.System.terminateExternalProcess({ uuid: identity.uuid, timeout: 1000, killTree: true});
+            });
         });
     });
 


### PR DESCRIPTION
This PR is adding the function to handle listener callback in System.launchExternalProcess function. 
 [New Test](https://testing-dashboard.openfin.co/#/app/tests/5be097f6cb360141a7dfd1fb/edit)