### PR TITLE
RUN-4834 Updated Ack to send logId in a data payload

### DIFF
--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -305,7 +305,8 @@ export class Application extends EmitterBase<ApplicationEvents> {
     }
 
     /**
-     * Uploads app log to Log Manager and returns a promise containing the log id.
+     * Sends a message to the RVM to upload the application's logs. On success,
+     * an object containing logId is returned.
      * @return {Promise.<any>}
      * @tutorial Application.sendApplicationLog
      */

--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -22,6 +22,10 @@ export interface ApplicationInfo {
     runtime: object;
 }
 
+export interface LogInfo {
+    logId: string;
+}
+
 export class NavigationRejectedReply extends Reply<'window-navigation-rejected', void> {
     public sourceName: string;
     public url: string;
@@ -310,7 +314,7 @@ export class Application extends EmitterBase<ApplicationEvents> {
      * @return {Promise.<any>}
      * @tutorial Application.sendApplicationLog
      */
-    public async sendApplicationLog(): Promise<any> {
+    public async sendApplicationLog(): Promise<LogInfo> {
         const { payload } = await this.wire.sendAction('send-application-log', this.identity);
         return payload.data;
     }

--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -305,6 +305,16 @@ export class Application extends EmitterBase<ApplicationEvents> {
     }
 
     /**
+     * Uploads app log to Log Manager and returns a promise containing the log id.
+     * @return {Promise.<any>}
+     * @tutorial Application.sendApplicationLog
+     */
+    public async sendApplicationLog(): Promise<any> {
+        const { payload } = await this.wire.sendAction('send-application-log', this.identity);
+        return payload.data;
+    }
+
+    /**
      * Adds a customizable icon in the system tray and notifies the application when clicked.
      * @param { string } iconUrl Image URL to be used as the icon
      * @return {Promise.<void>}

--- a/tutorials/Application.sendApplicationLog.md
+++ b/tutorials/Application.sendApplicationLog.md
@@ -1,4 +1,5 @@
-Uploads app log to Log Manager and returns a promise containing the log id.
+Sends a message to the RVM to upload the application's logs. On success,
+an object containing logId is returned.
 
  ### Example
 ```js
@@ -6,5 +7,6 @@ async function sendLog() {
     const app = await fin.Application.getCurrent();
     return await app.sendApplicationLog();
 }
- sendLog().then(info => console.log(info)).catch(err => console.log(err));
+
+sendLog().then(info => console.log(info.logId)).catch(err => console.log(err));
 ```

--- a/tutorials/Application.sendApplicationLog.md
+++ b/tutorials/Application.sendApplicationLog.md
@@ -1,0 +1,10 @@
+Uploads app log to Log Manager and returns a promise containing the log id.
+
+ ### Example
+```js
+async function sendLog() {
+    const app = await fin.Application.getCurrent();
+    return await app.sendApplicationLog();
+}
+ sendLog().then(info => console.log(info)).catch(err => console.log(err));
+```


### PR DESCRIPTION
Added sendApplicationLog API.

Returns a promise with the logId stored in the Log Manager.