### PR TITLE
RUN-4644 Add calls to start/quit application

### DIFF
--- a/docs.README.md
+++ b/docs.README.md
@@ -81,11 +81,11 @@ For a single-page reference to all application settings and configuration option
 * {@link Window#blur blur} _Window_
 * {@link Window#bringToFront bringToFront} _Window_
 * {@link System#clearCache clearCache} _System_
-* {@link Application#close close} _Application_
+* {@link Application#quit quit} _Application_
 * {@link Notification#close close} _Notification_
 * {@link Window#close close} _Window_
 * {@link InterApplicationBus.Channel.connect connect} _Channel_
-* {@link Application.create create} _Application_
+* {@link Application.start start} _Application_
 * {@link InterApplicationBus.Channel.create create} _Channel_
 * {@link Window.create create} _Window_
 * {@link Application.createFromManifest createFromManifest} _Application_
@@ -202,7 +202,6 @@ For a single-page reference to all application settings and configuration option
 * {@link Window#resizeTo resizeTo} _Window_
 * {@link Application#restart restart} _Application_
 * {@link Window#restore restore} _Window_
-* {@link Application#run run} _Application_
 * {@link Application#scheduleRestart scheduleRestart} _Application_
 * {@link InterApplicationBus#send send} _InterApplicationBus_
 * {@link Notification#sendMessage sendMessage} _Notification_

--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -69,13 +69,12 @@ export default class ApplicationModule extends Base {
     public wrapSync(identity: Identity): Application {
         return new Application(this.wire, identity);
     }
-
-    private _create(appOptions: ApplicationOption): Promise<Application> {
-        return this.wire.sendAction('create-application', appOptions)
-            .then(() => this.wrap({ uuid: appOptions.uuid }));
+    // tslint:disable-next-line:function-name
+    private async _create(appOptions: ApplicationOption): Promise<Application> {
+        await this.wire.sendAction('create-application', appOptions);
+        return await this.wrap({ uuid: appOptions.uuid });
     }
-    // tslint:disable-next-line:no-unused-variable
-    private create(appOptions: ApplicationOption): Promise<Application> {
+    public create(appOptions: ApplicationOption): Promise<Application> {
         console.warn('Deprecation Warning: fin.Application.create is deprecated. Please use fin.Application.start');
         return this._create(appOptions);
     }
@@ -128,8 +127,7 @@ export default class ApplicationModule extends Base {
         }, identity));
         return app;
     }
-    // tslint:disable-next-line:no-unused-variable
-    private createFromManifest(manifestUrl: string): Promise<Application> {
+    public createFromManifest(manifestUrl: string): Promise<Application> {
         console.warn('Deprecation Warning: fin.Application.createFromManifest is deprecated. Please use fin.Application.startFromManifest');
         return this.wire.sendAction('get-application-manifest', { manifestUrl })
             .then(({ payload }) => this.wrap({ uuid: payload.data.startup_app.uuid })
@@ -192,11 +190,11 @@ export class Application extends EmitterBase<ApplicationEvents> {
         await this._close(force);
         await this.wire.sendAction('destroy-application', Object.assign({force}, this.identity));
     }
+    //tslint:disable-next-line:function-name
     private _close(force: boolean = false): Promise<void> {
         return this.wire.sendAction('close-application', Object.assign({}, this.identity, { force })).then(() => undefined);
     }
-    // tslint:disable-next-line:no-unused-variable
-    private close(force: boolean = false): Promise<void> {
+    public close(force: boolean = false): Promise<void> {
         console.warn('Deprecation Warning: Application.close is deprecated Please use Application.quit');
         return this._close(force);
     }
@@ -320,7 +318,7 @@ export class Application extends EmitterBase<ApplicationEvents> {
     }
 
     // tslint:disable-next-line:no-unused-variable
-    private run(): Promise<void> {
+    public run(): Promise<void> {
         console.warn('Deprecation Warning: Application.run is deprecated Please use fin.Application.start');
         return this.wire.sendAction('run-application', Object.assign({}, this.identity, {
             manifestUrl: this._manifestUrl

--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -70,16 +70,26 @@ export default class ApplicationModule extends Base {
         return new Application(this.wire, identity);
     }
 
-    /**
-     * Creates a new Application.
-     * @param { ApplicationOption } appOptions
-     * @return {Promise.<Application>}
-     * @tutorial Application.create
-     * @static
-     */
-    public create(appOptions: ApplicationOption): Promise<Application> {
+    private _create(appOptions: ApplicationOption): Promise<Application> {
         return this.wire.sendAction('create-application', appOptions)
             .then(() => this.wrap({ uuid: appOptions.uuid }));
+    }
+    // tslint:disable-next-line:no-unused-variable
+    private create(appOptions: ApplicationOption): Promise<Application> {
+        console.warn('Deprecation Warning: fin.Application.create is deprecated. Please use fin.Application.start');
+        return this._create(appOptions);
+    }
+    /**
+    * Creates and starts a new Application.
+    * @param { ApplicationOption } appOptions
+    * @return {Promise.<Application>}
+    * @tutorial Application.start
+    * @static
+    */
+    public async start(appOptions: ApplicationOption): Promise<Application> {
+        const app = await this._create(appOptions);
+        await this.wire.sendAction('run-application', { uuid: appOptions.uuid });
+        return app;
     }
 
     /**
@@ -103,13 +113,24 @@ export default class ApplicationModule extends Base {
     }
 
     /**
-     * Retrieves application's manifest and returns a wrapped application.
+     * Retrieves application's manifest and returns a running instance of the application.
      * @param {string} manifestUrl - The URL of app's manifest.
      * @return {Promise.<Application>}
-     * @tutorial Application.createFromManifest
+     * @tutorial Application.startFromManifest
      * @static
      */
-    public createFromManifest(manifestUrl: string): Promise<Application> {
+    public async startFromManifest(manifestUrl: string): Promise<Application> {
+        const payload: any = await this.wire.sendAction('get-application-manifest', { manifestUrl });
+        const identity = { uuid: payload.data.startup_app.uuid };
+        const app = await this.wrap(identity);
+        await this.wire.sendAction('run-application', Object.assign({
+            manifestUrl: manifestUrl
+        }, identity));
+        return app;
+    }
+    // tslint:disable-next-line:no-unused-variable
+    private createFromManifest(manifestUrl: string): Promise<Application> {
+        console.warn('Deprecation Warning: fin.Application.createFromManifest is deprecated. Please use fin.Application.startFromManifest');
         return this.wire.sendAction('get-application-manifest', { manifestUrl })
             .then(({ payload }) => this.wrap({ uuid: payload.data.startup_app.uuid })
                 .then(app => {
@@ -161,13 +182,23 @@ export class Application extends EmitterBase<ApplicationEvents> {
 
     /**
      * Closes the application and any child windows created by the application.
+     * Cleans the application from state so it is no longer found in getAllApplications.
      * @param { boolean } [force = false] Close will be prevented from closing when force is false and
      *  ‘close-requested’ has been subscribed to for application’s main window.
      * @return {Promise.<boolean>}
-     * @tutorial Application.close
+     * @tutorial Application.quit
      */
-    public close(force: boolean = false): Promise<void> {
+    public async quit(force: boolean = false): Promise<void> {
+        await this._close(force);
+        await this.wire.sendAction('destroy-application', Object.assign({force}, this.identity));
+    }
+    private _close(force: boolean = false): Promise<void> {
         return this.wire.sendAction('close-application', Object.assign({}, this.identity, { force })).then(() => undefined);
+    }
+    // tslint:disable-next-line:no-unused-variable
+    private close(force: boolean = false): Promise<void> {
+        console.warn('Deprecation Warning: Application.close is deprecated Please use Application.quit');
+        return this._close(force);
     }
 
     /**
@@ -288,12 +319,9 @@ export class Application extends EmitterBase<ApplicationEvents> {
         return this.wire.sendAction('restart-application', this.identity).then(() => undefined);
     }
 
-    /**
-     * Runs the application. When the application is created, run must be called.
-     * @return {Promise.<void>}
-     * @tutorial Application.run
-     */
-    public run(): Promise<void> {
+    // tslint:disable-next-line:no-unused-variable
+    private run(): Promise<void> {
+        console.warn('Deprecation Warning: Application.run is deprecated Please use fin.Application.start');
         return this.wire.sendAction('run-application', Object.assign({}, this.identity, {
             manifestUrl: this._manifestUrl
         })).then(() => undefined);


### PR DESCRIPTION
This PR adds api calls to start/quit an application. These calls replace create/run/close and clean up core state. The old methods are undocumented and now have a deprecation warning but will need to be made private/removed in future prs. Needs a core pr which adds a call to clean up core state.