### PR TITLE
RUN-4974 remove --enable-multi-runtime flag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,7 +44,7 @@ module.exports = function (grunt) {
     const target = grunt.option('target');
     const shouldBuildCore = grunt.option('build-core');
     const uuid = 'testapp';
-    const args = '--enable-multi-runtime --debug=5858';
+    const args = '--inspect=9222';
     process.env.OF_VER = version;
     process.env.TEST_SERVER_PORT = serverParams.port;
 

--- a/test/multi-runtime-utils.ts
+++ b/test/multi-runtime-utils.ts
@@ -45,7 +45,6 @@ async function spawnRealm(version: string, realm?: string, args?: Array<string>)
                 const port = ++ws_port;
 
                 args = args || [
-                    '--enable-multi-runtime',
                     '--enable-mesh',
                     `--security-realm=${realm}`
                     // '--v=1',


### PR DESCRIPTION
This PR removed useless flag: --enable-multi-runtime. Instead, we use --enable-mesh to achieve it and use --security-realm alone to disable mesh.