### PR TITLE
RUN-5123 getWebWindow

### DIFF
--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -764,6 +764,15 @@ export class _Window extends EmitterBase<WindowEvents> {
     }
 
     /**
+     * Gets the [Window Object](https://developer.mozilla.org/en-US/docs/Web/API/Window) previously getNativeWindow
+     * @return {object}
+     * @tutorial Window.getWebWindow
+     */
+    public getWebWindow(): Window {
+        return this.wire.environment.getWebWindow(this.identity);
+    }
+
+    /**
      * Determines if the window is a main window.
      * @return {boolean}
      * @tutorial Window.isMainWindow

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -1,4 +1,5 @@
 import { NewConnectConfig } from '../transport/wire';
+import { Identity } from '../identity';
 
 export interface Environment {
     writeToken(path: string, token: string): Promise<string>;
@@ -7,6 +8,7 @@ export interface Environment {
     getRandomId(): string;
     createChildWindow(options: any): Promise<any>;
     isWindowExists(uuid: string, name: string) : boolean;
+    getWebWindow(identity: Identity): Window;
 }
 
 export const notImplementedEnvErrorMsg = 'Not implemented in this environment';

--- a/src/environment/node-env.ts
+++ b/src/environment/node-env.ts
@@ -3,7 +3,8 @@ import { randomBytes } from 'crypto';
 import { Environment } from './environment';
 import { PortDiscovery } from '../transport/port-discovery';
 import { NewConnectConfig } from '../transport/wire';
-import { NotImplementedError } from '../transport/transport-errors';
+import { NotImplementedError, NotSupportedError } from '../transport/transport-errors';
+import { Identity } from '../identity';
 
 export default class NodeEnvironment implements Environment {
     private messageCounter = 0;
@@ -34,5 +35,8 @@ export default class NodeEnvironment implements Environment {
 
     public isWindowExists = (uuid: string, name: string): boolean => {
         throw new NotImplementedError('Not Implemented');
+    }
+    public getWebWindow = (identity: Identity): Window => {
+        throw new NotSupportedError('Not supported outside of OpenFin web context');
     }
 }

--- a/src/environment/openfin-env.ts
+++ b/src/environment/openfin-env.ts
@@ -1,6 +1,7 @@
 import { Environment } from './environment';
 import { NewConnectConfig } from '../transport/wire';
 import { NotImplementedError } from '../transport/transport-errors';
+import { Identity } from '../identity';
 
 declare var fin: any;
 
@@ -66,5 +67,9 @@ export default class OpenFinEnvironment implements Environment {
 
     public isWindowExists = (uuid: string, name: string): boolean => {
         return fin.__internal_.windowExists(uuid, name);
+    }
+
+    public getWebWindow = (identity: Identity): Window => {
+        return fin.__internal_.getWebWindow(identity.name);
     }
 }

--- a/tutorials/Window.getWebWindow.md
+++ b/tutorials/Window.getWebWindow.md
@@ -1,0 +1,61 @@
+Returns the [Window Object](https://developer.mozilla.org/en-US/docs/Web/API/Window) that is available via the global web context and returned by the Window interface's [open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) method. The target window needs to be in the same render process and same domain (same OpenFin Application).
+
+
+#### Injecting content into an empty window.
+In this example we create a blank child window and populte it with some simple html.
+```js
+(async ()=> {
+    try {
+        const winName = `child-window-${Date.now()}`;
+        const win = await fin.Window.create({
+            name: winName,
+            url: 'about:blank',
+            autoShow: false
+        });
+        win.getWebWindow().document.body.append = '<h1>Hello World</h1>';
+        await win.show();
+    } catch (err) {
+        console.error(err);
+    }
+})();
+```
+
+#### Cloning DOM elements from the parent window
+In this example we get clone an `h3` element from the parent window.
+```js
+(async ()=> {
+    try {
+        const currentWindow = await fin.Window.getCurrent();
+        const parentWindow = await currentWindow.getParentWindow();
+        const clonedH3 = parentWindow.getWebWindow().document.querySelector('h3').cloneNode(true);
+        document.body.append(clonedH3);
+
+    } catch (err) {
+        console.error(err);
+    }
+})();
+```
+
+#### Rendering on a child window via a library
+In this example we are using the [lit-html](https://lit-html.polymer-project.org/) template library to render content on a blank child window. you are not going to be able to copy paste this example without configuring the project correctly but this would demonstrate some templeting options available.
+```js
+(async ()=> {
+    try {
+        const win = await fin.Window.create({
+            name: `child-window-${Date.now()}`,
+            url: 'about:blank',
+            autoShow: false
+        });
+        const template = html`
+            <div>
+                <span>Click here: </span>
+                <button @click=${()=> console.log('Hello World!')}>log to the console</button>
+            </div>`;
+        render(template, win.getWebWindow().document.body);
+        await win.show();
+
+    } catch (err) {
+        console.error(err);
+    }
+})();
+```

--- a/tutorials/Window.getWebWindow.md
+++ b/tutorials/Window.getWebWindow.md
@@ -1,4 +1,4 @@
-Returns the [Window Object](https://developer.mozilla.org/en-US/docs/Web/API/Window) that is available via the global web context and returned by the Window interface's [open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) method. The target window needs to be in the same render process and same domain (same OpenFin Application).
+Returns the [Window Object](https://developer.mozilla.org/en-US/docs/Web/API/Window) that represents the web context of the target window. This is the same object that you would get from calling [window.open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) in a standard web context. The target window needs to be in the same application as the requesting window as well as comply with [same-origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) policy requirements.
 
 
 #### Injecting content into an empty window.
@@ -9,11 +9,9 @@ In this example we create a blank child window and populte it with some simple h
         const winName = `child-window-${Date.now()}`;
         const win = await fin.Window.create({
             name: winName,
-            url: 'about:blank',
-            autoShow: false
+            url: 'about:blank'
         });
-        win.getWebWindow().document.body.append = '<h1>Hello World</h1>';
-        await win.show();
+        win.getWebWindow().document.write('<h1>Hello World</h1>');
     } catch (err) {
         console.error(err);
     }
@@ -21,7 +19,7 @@ In this example we create a blank child window and populte it with some simple h
 ```
 
 #### Cloning DOM elements from the parent window
-In this example we get clone an `h3` element from the parent window.
+In this example we clone an `h3` element from the parent window.
 ```js
 (async ()=> {
     try {
@@ -43,8 +41,7 @@ In this example we are using the [lit-html](https://lit-html.polymer-project.org
     try {
         const win = await fin.Window.create({
             name: `child-window-${Date.now()}`,
-            url: 'about:blank',
-            autoShow: false
+            url: 'about:blank'
         });
         const template = html`
             <div>
@@ -52,7 +49,6 @@ In this example we are using the [lit-html](https://lit-html.polymer-project.org
                 <button @click=${()=> console.log('Hello World!')}>log to the console</button>
             </div>`;
         render(template, win.getWebWindow().document.body);
-        await win.show();
 
     } catch (err) {
         console.error(err);


### PR DESCRIPTION

#### Description of Change
Added the ability to get the [Window Object](https://developer.mozilla.org/en-US/docs/Web/API/Window) previously available in the V1 API as `getNativeWindow`

- [ X ] PR description included and stakeholders cc'd
- [ X ] `npm test` passes
- [ X ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [X] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [X] PR release notes describe the change in a way relevant to app-developers


Notes: 
Added `getWebWindow` API that returns the [Window Object](https://developer.mozilla.org/en-US/docs/Web/API/Window).  Previously `getNativeWindow` in API V1

Test Results: 
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c9e79c1cb360141a7dfdf3a)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c9e7c0acb360141a7dfdf3b)