### PR TITLE
Explicitly Import URL Module

### DIFF
--- a/src/util/http.ts
+++ b/src/util/http.ts
@@ -1,6 +1,7 @@
 import { parse } from 'url';
 import { IncomingMessage } from 'http';
 import * as fs from 'fs';
+import { URL } from 'url';
 
 const getProxyVar = () => {
     return process.env.HTTPS_PROXY ||


### PR DESCRIPTION
It looks like the URL module is implicitly imported in Node 10. Adding the import so it will work with versions prior to Node 10.