### PR TITLE
RUN-5182: reject win creation errors to caller

### DIFF
--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -526,7 +526,7 @@ export class _Window extends EmitterBase<WindowEvents> {
                     //common for main windows, we do not want to expose this error. here just to have a debug target.
                     //console.error(e);
                 }
-            });
+            }).catch(reject);
         });
     }
 


### PR DESCRIPTION
Jira ticket: https://appoji.jira.com/browse/RUN-5182

Currently failing test that will pass with this change: https://testing-dashboard.openfin.co/#/app/tests/5cc20dbccb360141a7dfe17e/edit

Without this change, the js-adapter throws an error when attempting to create a window with the uuid and name of a pre-existing window. With this change, that error is passed back to the caller, allowing application code to handle it.

Note: I think `Min version` should probably be set in my dashboard test, but I'm not sure what it should be set to. Any pointers on that front much appreciated.