### PR TITLE
RUN-5222 get service configuration

### DIFF
--- a/src/api/system/external-process.ts
+++ b/src/api/system/external-process.ts
@@ -41,3 +41,7 @@ export interface ExternalProcessInfo {
     pid: number;
     listener?: LaunchExternalProcessListener;
 }
+
+export interface ServiceConfiguration {
+    name: string;
+}

--- a/src/api/system/system.ts
+++ b/src/api/system/system.ts
@@ -13,7 +13,7 @@ import { RuntimeInfo } from './runtime-info';
 import { Entity, EntityInfo } from './entity';
 import { HostSpecs } from './host-specs';
 import { ExternalProcessRequestType , TerminateExternalRequestType, ExternalConnection, ExitCode,
-    ExternalProcessInfo } from './external-process';
+    ExternalProcessInfo, ServiceConfiguration } from './external-process';
 import Transport from '../../transport/transport';
 import { CookieInfo, CookieOption } from './cookie';
 import { RegistryInfo } from './registry-info';
@@ -417,6 +417,12 @@ import { _Window } from '../window/window';
  * @property { Array<WindowDetail> } childWindows The array of child windows details
  * @property { WindowDetail } mainWindow The main window detail
  * @property { string } uuid The uuid of the application
+ */
+
+ /**
+ * Service identifier
+ * @typedef { object } ServiceIdentifier
+ * @property { string } name The name of the service
  */
 
 /**
@@ -1121,18 +1127,18 @@ export default class System extends EmitterBase<SystemEvents> {
     }
 
     /**
-     * Returns the value of the blob blah blah
+     * Returns the json blob found in the [desktop owner settings](https://openfin.co/documentation/desktop-owner-settings/)
+     * for the specified service.
+     * More information about desktop services can be found [here](https://developers.openfin.co/docs/desktop-services).
+     * @param { ServiceIdentifier } serviceIdentifier An object containing a name key that identifies the service.
+     * @return {Promise.<ServiceConfiguration>}
+     * @tutorial System.getServiceConfiguration
      */
-    public async getServiceConfiguration(identifier: {name: string}): Promise<any /*ServiceConfiguration*/> {
+    public async getServiceConfiguration(identifier: {name: string}): Promise<ServiceConfiguration> {
         if (typeof identifier.name !== 'string') {
             throw new Error('Must provide an object with a `name` property having a string value');
         }
         const { name } = identifier;
-        return this.wire.sendAction('get-service-configuration', {name});
+        return this.wire.sendAction('get-service-configuration', {name}).then(({ payload }) => payload.data);
     }
-}
-
-interface ServiceConfiguration {
-    name: string;
-    config: any;
 }

--- a/src/api/system/system.ts
+++ b/src/api/system/system.ts
@@ -1119,4 +1119,20 @@ export default class System extends EmitterBase<SystemEvents> {
     public registerExternalConnection(uuid: string): Promise<ExternalConnection> {
         return this.wire.sendAction('register-external-connection', {uuid}).then(({ payload }) => payload.data);
     }
+
+    /**
+     * Returns the value of the blob blah blah
+     */
+    public async getServiceConfiguration(identifier: {name: string}): Promise<any /*ServiceConfiguration*/> {
+        if (typeof identifier.name !== 'string') {
+            throw new Error('Must provide an object with a `name` property having a string value');
+        }
+        const { name } = identifier;
+        return this.wire.sendAction('get-service-configuration', {name});
+    }
+}
+
+interface ServiceConfiguration {
+    name: string;
+    config: any;
 }

--- a/src/api/system/system.ts
+++ b/src/api/system/system.ts
@@ -425,6 +425,10 @@ import { _Window } from '../window/window';
  * @property { string } name The name of the service
  */
 
+ interface ServiceIdentifier {
+     name: string;
+ }
+
 /**
  * An object representing the core of OpenFin Runtime. Allows the developer
  * to perform system-level actions, such as accessing logs, viewing processes,
@@ -1134,11 +1138,11 @@ export default class System extends EmitterBase<SystemEvents> {
      * @return {Promise.<ServiceConfiguration>}
      * @tutorial System.getServiceConfiguration
      */
-    public async getServiceConfiguration(identifier: {name: string}): Promise<ServiceConfiguration> {
-        if (typeof identifier.name !== 'string') {
+    public async getServiceConfiguration(serviceIdentifier: ServiceIdentifier): Promise<ServiceConfiguration> {
+        if (typeof serviceIdentifier.name !== 'string') {
             throw new Error('Must provide an object with a `name` property having a string value');
         }
-        const { name } = identifier;
+        const { name } = serviceIdentifier;
         return this.wire.sendAction('get-service-configuration', {name}).then(({ payload }) => payload.data);
     }
 }

--- a/tutorials/getServiceConfiguration.md
+++ b/tutorials/getServiceConfiguration.md
@@ -1,0 +1,9 @@
+Given an object with a name key containing the name of the service for which you would like the configuration, `getServiceConfiguration` will return the JSON blob found in the [desktop owner settings](https://openfin.co/documentation/desktop-owner-settings/) file for the specified service. More information about desktop services can be found [here](https://developers.openfin.co/docs/desktop-services). This call will reject if the desktop owner settings file is not present, not correctly formatted, or if the service requested is not configured or configured incorrectly.
+
+
+
+# Example
+Here we are using the [layouts](https://github.com/HadoukenIO/layouts-service) service.
+```js
+fin.System.getServiceConfiguration({name:'layouts'}).then(console.log).catch(console.error)
+```


### PR DESCRIPTION
This adds the ability to request service configurations found in the desktop owner settings file.

It is linked to [this core pr](https://github.com/HadoukenIO/core/pull/773). 

Note: this requires [this](https://github.com/openfin/openfinrvm/commit/57cc300a3989feb6e5324d53b8f13059f68b5328) RVM change to be released