### PR TITLE
[RUN-5071] Add option to window resize/movement APIs to allow windows to move independently of their group

### DIFF
--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -343,6 +343,11 @@ interface WindowMovementOptions {
  */
 
 /**
+ * @typedef { Object } WindowMovementOptions
+ * @property { boolean } moveIndependently - Move a window indpendently of its group or along with its group. Defaults to false.
+ */
+
+/**
  * @typedef {object} Transition
  * @property {Opacity} opacity - The Opacity transition
  * @property {Position} position - The Position transition

--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -1001,7 +1001,7 @@ export class _Window extends EmitterBase<WindowEvents> {
      * @tutorial Window.setBounds
      */
     public setBounds(bounds: Bounds, options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
-        return this.wire.sendAction('set-window-bounds', Object.assign({}, this.identity, { bounds, options })).then(() => undefined);
+        return this.wire.sendAction('set-window-bounds', Object.assign({}, this.identity, { ...bounds, options })).then(() => undefined);
     }
 
     /**

--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -945,7 +945,7 @@ export class _Window extends EmitterBase<WindowEvents> {
      * @tutorial Window.resizeBy
      */
     public resizeBy(deltaWidth: number, deltaHeight: number, anchor: AnchorType,
-        options: WindowMovementOptions = { moveIndependently: true }): Promise<void> {
+        options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
         return this.wire.sendAction('resize-window-by', Object.assign({}, this.identity, {
             deltaWidth: Math.floor(deltaWidth),
             deltaHeight: Math.floor(deltaHeight),

--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -107,6 +107,10 @@ export interface Area {
     y: number;
 }
 
+interface WindowMovementOptions {
+    moveIndependently: boolean;
+}
+
 /**
  * @typedef {object} Window~options
  * @summary Window creation options.
@@ -901,22 +905,32 @@ export class _Window extends EmitterBase<WindowEvents> {
      * Moves the window by a specified amount.
      * @param { number } deltaLeft The change in the left position of the window
      * @param { number } deltaTop The change in the top position of the window
+     * @param { WindowMovementOptions } options Optional parameters to modify window movement
      * @return {Promise.<void>}
      * @tutorial Window.moveBy
      */
-    public moveBy(deltaLeft: number, deltaTop: number): Promise<void> {
-        return this.wire.sendAction('move-window-by', Object.assign({}, this.identity, { deltaLeft, deltaTop })).then(() => undefined);
+    public moveBy(deltaLeft: number, deltaTop: number, options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
+        return this.wire.sendAction('move-window-by', Object.assign({}, this.identity, {
+            deltaLeft,
+            deltaTop,
+            options
+        })).then(() => undefined);
     }
 
     /**
      * Moves the window to a specified location.
      * @param { number } left The left position of the window
      * @param { number } top The top position of the window
+     * @param { WindowMovementOptions } options Optional parameters to modify window movement
      * @return {Promise.<void>}
      * @tutorial Window.moveTo
      */
-    public moveTo(left: number, top: number): Promise<void> {
-        return this.wire.sendAction('move-window', Object.assign({}, this.identity, { left, top })).then(() => undefined);
+    public moveTo(left: number, top: number, options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
+        return this.wire.sendAction('move-window', Object.assign({}, this.identity, {
+            left,
+            top,
+            options
+        })).then(() => undefined);
     }
 
     /**
@@ -926,14 +940,17 @@ export class _Window extends EmitterBase<WindowEvents> {
      * @param { AnchorType } anchor Specifies a corner to remain fixed during the resize.
      * Can take the values: "top-left", "top-right", "bottom-left", or "bottom-right".
      * If undefined, the default is "top-left"
+     * @param { WindowMovementOptions } options Optional parameters to modify window movement
      * @return {Promise.<void>}
      * @tutorial Window.resizeBy
      */
-    public resizeBy(deltaWidth: number, deltaHeight: number, anchor: AnchorType): Promise<void> {
+    public resizeBy(deltaWidth: number, deltaHeight: number, anchor: AnchorType,
+        options: WindowMovementOptions = { moveIndependently: true }): Promise<void> {
         return this.wire.sendAction('resize-window-by', Object.assign({}, this.identity, {
             deltaWidth: Math.floor(deltaWidth),
             deltaHeight: Math.floor(deltaHeight),
-            anchor
+            anchor,
+            options
         })).then(() => undefined);
     }
 
@@ -944,14 +961,17 @@ export class _Window extends EmitterBase<WindowEvents> {
      * @param { AnchorType } anchor Specifies a corner to remain fixed during the resize.
      * Can take the values: "top-left", "top-right", "bottom-left", or "bottom-right".
      * If undefined, the default is "top-left"
+     * @param { WindowMovementOptions } options Optional parameters to modify window movement
      * @return {Promise.<void>}
      * @tutorial Window.resizeTo
      */
-    public resizeTo(width: number, height: number, anchor: AnchorType): Promise<void> {
+    public resizeTo(width: number, height: number, anchor: AnchorType,
+        options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
         return this.wire.sendAction('resize-window', Object.assign({}, this.identity, {
             width: Math.floor(width),
             height: Math.floor(height),
-            anchor
+            anchor,
+            options
         })).then(() => undefined);
     }
 
@@ -976,11 +996,12 @@ export class _Window extends EmitterBase<WindowEvents> {
     /**
      * Sets the window's size and position.
      * @property { Bounds } bounds This is a * @type {string} name - name of the window.object that holds the propertys of
+     * @param { WindowMovementOptions } options Optional parameters to modify window movement
      * @return {Promise.<void>}
      * @tutorial Window.setBounds
      */
-    public setBounds(bounds: Bounds): Promise<void> {
-        return this.wire.sendAction('set-window-bounds', Object.assign({}, this.identity, bounds)).then(() => undefined);
+    public setBounds(bounds: Bounds, options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
+        return this.wire.sendAction('set-window-bounds', Object.assign({}, this.identity, { bounds, options })).then(() => undefined);
     }
 
     /**
@@ -1002,14 +1023,17 @@ export class _Window extends EmitterBase<WindowEvents> {
      * @param { number } top The right position of the window
      * @param { boolean } force Show will be prevented from closing when force is false and
      * ‘show-requested’ has been subscribed to for application’s main window
+     * @param { WindowMovementOptions } options Optional parameters to modify window movement
      * @return {Promise.<void>}
      * @tutorial Window.showAt
      */
-    public showAt(left: number, top: number, force: boolean = false): Promise<void> {
+    public showAt(left: number, top: number, force: boolean = false,
+        options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
         return this.wire.sendAction('show-at-window', Object.assign({}, this.identity, {
             force,
             left: Math.floor(left),
-            top: Math.floor(top)
+            top: Math.floor(top),
+            options
         })).then(() => undefined);
     }
 

--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -335,7 +335,7 @@ interface WindowMovementOptions {
  */
 
 /**
- * @typedef { Object } Area
+ * @typedef { object } Area
  * @property { number } height Area's height
  * @property { number } width Area's width
  * @property { number } x X coordinate of area's starting point
@@ -343,7 +343,7 @@ interface WindowMovementOptions {
  */
 
 /**
- * @typedef { Object } WindowMovementOptions
+ * @typedef { object } WindowMovementOptions
  * @property { boolean } moveIndependently - Move a window indpendently of its group or along with its group. Defaults to false.
  */
 

--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -344,7 +344,7 @@ interface WindowMovementOptions {
 
 /**
  * @typedef { object } WindowMovementOptions
- * @property { boolean } moveIndependently - Move a window indpendently of its group or along with its group. Defaults to false.
+ * @property { boolean } moveIndependently - Move a window independently of its group or along with its group. Defaults to false.
  */
 
 /**

--- a/tutorials/Window.moveBy.md
+++ b/tutorials/Window.moveBy.md
@@ -1,5 +1,13 @@
 Moves the window by a specified amount
 
+### Options Object
+
+```js
+{
+    moveIndependently: true // Move a window indpendently of its group or along with its group. Defaults to false.
+}
+```
+
 # Example
 ```js
 async function createWin() {
@@ -14,7 +22,10 @@ async function createWin() {
 
 async function moveBy(left, top) {
     const win = await createWin();
-    return await win.moveBy(left, top);
+    const options = {
+        moveIndependently: false
+    }
+    return await win.moveBy(left, top, options);
 }
 
 moveBy(580, 300).then(() => console.log('Moved')).catch(err => console.log(err));

--- a/tutorials/Window.moveTo.md
+++ b/tutorials/Window.moveTo.md
@@ -1,5 +1,13 @@
 Moves the window to a specified location
 
+### Options Object
+
+```js
+{
+    moveIndependently: true // Move a window indpendently of its group or along with its group. Defaults to false.
+}
+```
+
 # Example
 ```js
 async function createWin() {
@@ -14,7 +22,10 @@ async function createWin() {
 
 async function moveTo(left, top) {
     const win = await createWin();
-    return await win.moveTo(left, top)
+    const options = {
+        moveIndependently: false
+    }
+    return await win.moveTo(left, top, options)
 }
 
 moveTo(580, 300).then(() => console.log('Moved')).catch(err => console.log(err))

--- a/tutorials/Window.resizeBy.md
+++ b/tutorials/Window.resizeBy.md
@@ -1,5 +1,13 @@
 Resizes the window by a specified amount
 
+### Options Object
+
+```js
+{
+    moveIndependently: true // Move a window indpendently of its group or along with its group. Defaults to false.
+}
+```
+
 # Example
 ```js
 async function createWin() {
@@ -14,7 +22,10 @@ async function createWin() {
 
 async function resizeBy(left, top, anchor) {
     const win = await createWin();
-    return await win.resizeBy(left, top, anchor)
+    const options = {
+        moveIndependently: false
+    }
+    return await win.resizeBy(left, top, anchor, options)
 }
 
 resizeBy(580, 300, 'top-right').then(() => console.log('Resized')).catch(err => console.log(err));

--- a/tutorials/Window.resizeTo.md
+++ b/tutorials/Window.resizeTo.md
@@ -1,5 +1,13 @@
 Resizes the window to the specified dimensions
 
+### Options Object
+
+```js
+{
+    moveIndependently: true // Move a window indpendently of its group or along with its group. Defaults to false.
+}
+```
+
 # Example
 ```js
 async function createWin() {
@@ -14,7 +22,10 @@ async function createWin() {
 
 async function resizeTo(left, top, anchor) {
     const win = await createWin();
-    return await win.resizeTo(left, top, anchor);
+    const options = {
+        moveIndependently: false
+    }
+    return await win.resizeTo(left, top, anchor, options);
 }
 
 resizeTo(580, 300, 'top-left').then(() => console.log('Resized')).catch(err => console.log(err));

--- a/tutorials/Window.setBounds.md
+++ b/tutorials/Window.setBounds.md
@@ -1,5 +1,13 @@
 Sets the window's size and position
 
+### Options Object
+
+```js
+{
+    moveIndependently: true // Move a window indpendently of its group or along with its group. Defaults to false.
+}
+```
+
 # Example
 ```js
 async function createWin() {
@@ -14,7 +22,10 @@ async function createWin() {
 
 async function setBounds(bounds) {
     const win = await createWin();
-    return await win.setBounds();
+    const options = {
+        moveIndependently: false
+    }
+    return await win.setBounds(bounds, options);
 }
 
 setBounds({

--- a/tutorials/Window.showAt.md
+++ b/tutorials/Window.showAt.md
@@ -1,5 +1,13 @@
 Shows the window if it is hidden at the specified location
 
+### Options Object
+
+```js
+{
+    moveIndependently: true // Move a window indpendently of its group or along with its group. Defaults to false.
+}
+```
+
 # Example
 ```js
 async function createWin() {
@@ -14,7 +22,10 @@ async function createWin() {
 
 async function showAt(left, top) {
     const win = await createWin();
-    return await win.showAt(left, top)
+    const options = {
+        moveIndependently: false
+    }
+    return await win.showAt(left, top, options)
 }
 
 showAt(580, 300).then(() => console.log('Showing at')).catch(err => console.log(err));


### PR DESCRIPTION
Associated with this `core` PR: https://github.com/HadoukenIO/core/pull/780
JIRA Ticket: https://appoji.jira.com/browse/RUN-5071

**[RUN-5071] Add option to window resize/movement APIs to allow windows to move independently of their group**

**Description:**
When we call the move/resize APIs for grouped windows, we now add a `moveIndependently` option in the options object for that call. If that option is set to `true`, we move that window independently of the rest of its group.

**Questions:**
Automated tests for all functions have been added to the `testing-dashboard`, but are currently private. When should I make them public? 

Not sure how linting is handled for the js-adapter? I formatted it according to the rest of the surrounding code.

Should I also add in the relevant code examples/documentation for this PR, or should we not publicize these options yet?

We could think about taking the APIs that have multiple args and collapsing them into one object, but that's probably a discussion for another time. 
