### PR TITLE
[N/A] Add bounds to TrayIconClicked event

### DIFF
--- a/src/api/events/application.ts
+++ b/src/api/events/application.ts
@@ -1,5 +1,6 @@
 import { WindowEvent, BaseEventMap, ApplicationEvent } from './base';
 import { WindowAlertRequestedEvent, WindowAuthRequestedEvent, WindowEndLoadEvent, PropagatedWindowEvents } from './window';
+import Bounds from '../window/bounds';
 
 export interface CrashedEvent {
     reason: 'normal-termination' | 'abnormal-termination' | 'killed' | 'crashed' | 'still-running' | 'launch-failed' | 'out-of-memory';
@@ -11,6 +12,7 @@ export interface RunRequestedEvent<Topic, Type> extends ApplicationEvent<Topic, 
 
 export interface TrayIconClicked<Topic, Type> extends ApplicationEvent<Topic, Type> {
     button: 0 | 1 | 2;
+    bounds: Bounds;
     x: number;
     y: number;
     monitorInfo: any;


### PR DESCRIPTION
This PR adds the bounds property to the `tray-icon-clicked` to match the shape of the event.