### PR TITLE
RUN-5316: Fix failing uuid-enforcement test

### DIFF
--- a/test/multi-runtime-utils.ts
+++ b/test/multi-runtime-utils.ts
@@ -203,12 +203,17 @@ export function killByruntime(runtimeProcess: RuntimeProcess) {
     runtimeProcess.runtime.kill();
 }
 
-async function closeAndClean(runtimeProcess: RuntimeProcess): Promise<void> {
-    killByruntime(runtimeProcess);
-    // give some time for rvm process to be killed
-    await delayPromise(DELAY_MS);
-    const cachePath = await realmCachePath(runtimeProcess.realm);
-    rimraf.sync(cachePath);
+async function closeAndClean(runtimeProcess: RuntimeProcess): Promise<void | object> {
+    return new Promise(async (resolve, reject) => {
+        killByruntime(runtimeProcess);
+        const cachePath = await realmCachePath(runtimeProcess.realm);
+        rimraf(cachePath, (err) => {
+            if (err) {
+                reject(err);
+            }
+            resolve();
+        });
+    });
 }
 
 export async function launchAndConnect(version: string = process.env.OF_VER,


### PR DESCRIPTION
JIRA: https://appoji.jira.com/browse/RUN-5316

Was able to repro failing test by reducing RAM allocation for my VM to 2gb.

Appears to be a timing issue: if killing the rvm process has not finished before we attempt to delete the cache, we get an EPERM error. Switching to rimraf's async api fixes the issue (it automatically retries a few times if the first attempt fails).

Would appreciate if a couple people could pull this branch and run locally just to make sure the issue is fixed. Consistently works on my machine, but I was not initially seeing the failure either.
