### PR TITLE
RUN-5254 updated typescript to 3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1415,7 +1415,7 @@
         },
         "eventemitter2": {
             "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+            "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
             "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
             "dev": true
         },
@@ -1781,7 +1781,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -1802,12 +1803,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -1822,17 +1825,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -1949,7 +1955,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -1961,6 +1968,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -1975,6 +1983,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -1982,12 +1991,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2006,6 +2017,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -2086,7 +2098,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -2098,6 +2111,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -2183,7 +2197,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -2219,6 +2234,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2238,6 +2254,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -2281,12 +2298,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -5037,9 +5056,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+            "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
             "dev": true
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "ts-loader": "^5.3.1",
         "tslint": "^4.5.1",
         "tslint-microsoft-contrib": "^4.0.1",
-        "typescript": "^2.9.2",
+        "typescript": "^3.5.1",
         "webpack": "^4.26.1"
     },
     "dependencies": {

--- a/test/window.test.ts
+++ b/test/window.test.ts
@@ -285,8 +285,8 @@ describe('Window.', function() {
                 return testWindow.moveBy(1, 1)
                     .then(() => testWindow.getBounds()
                         .then(data => {
-                            return assert(data.top === bounds.top + 1, `Expected ${data.top} to be ${bounds.top + 1}`) &&
-                                assert(data.left === bounds.left + 1, `Expected ${data.top} to be ${bounds.top + 1}`);
+                            assert(data.top === bounds.top + 1, `Expected ${data.top} to be ${bounds.top + 1}`);
+                            assert(data.left === bounds.left + 1, `Expected ${data.top} to be ${bounds.top + 1}`);
                         }));
             });
 
@@ -300,8 +300,8 @@ describe('Window.', function() {
             return testWindow.moveTo(10, 10)
                 .then(() => testWindow.getBounds()
                     .then(data => {
-                        return assert(data.top === 10, `Expected ${data.top} to be 10`) &&
-                            assert(data.left === 10, `Expected ${data.left} to be 10`);
+                        assert(data.top === 10, `Expected ${data.top} to be 10`);
+                        assert(data.left === 10, `Expected ${data.left} to be 10`);
                     }));
         });
 
@@ -387,8 +387,8 @@ describe('Window.', function() {
             return testWindow.showAt(10, 10)
                 .then(() => testWindow.getBounds()
                     .then(data => {
-                        return assert(data.top === 10, `Expected ${data.top} to be 10`) &&
-                            assert(data.left === 10, `Expected ${data.left} to be 10`);
+                        assert(data.top === 10, `Expected ${data.top} to be 10`);
+                        assert(data.left === 10, `Expected ${data.left} to be 10`);
                     }));
         });
     });


### PR DESCRIPTION
Updated typescript and had to change the tests do to a change in asserting truthiness on void.

Bumps to the same typescript version as the  [the core](https://github.com/HadoukenIO/core/pull/812).

Does this need a release note as far as definitely typed?