### PR TITLE
RUN-5286 v2 Api SetBounds will override identity if passed in bounds have a name.

### DIFF
--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -358,11 +358,12 @@ export class Application extends EmitterBase<ApplicationEvents> {
      */
     public async quit(force: boolean = false): Promise<void> {
         await this._close(force);
-        await this.wire.sendAction('destroy-application', Object.assign({force}, this.identity));
+        await this.wire.sendAction('destroy-application', Object.assign({ force }, this.identity));
     }
     //tslint:disable-next-line:function-name
     private _close(force: boolean = false): Promise<void> {
-        return this.wire.sendAction('close-application', Object.assign({}, this.identity, { force })).then(() => undefined);
+        return this.wire.sendAction('close-application', Object.assign({}, { force }, this.identity))
+            .then(() => undefined);
     }
     public close(force: boolean = false): Promise<void> {
         console.warn('Deprecation Warning: Application.close is deprecated Please use Application.quit');
@@ -379,7 +380,7 @@ export class Application extends EmitterBase<ApplicationEvents> {
             .then(({ payload }) => {
                 const identityList: Array<Identity> = [];
                 payload.data.forEach((winName: string) => {
-                    identityList.push({uuid: this.identity.uuid, name: winName});
+                    identityList.push({ uuid: this.identity.uuid, name: winName });
                 });
                 return this.windowListFromIdentityList(identityList);
             });
@@ -393,19 +394,19 @@ export class Application extends EmitterBase<ApplicationEvents> {
      */
     public getGroups(): Promise<Array<Array<_Window>>> {
         const winGroups: Array<Array<_Window>> = <Array<Array<_Window>>>[];
-        return this.wire.sendAction('get-application-groups', Object.assign({}, this.identity, {
-                crossApp: true // cross app group supported
-            })).then(({ payload }) => {
-                payload.data.forEach((windowList: any[], index: number) => {
-                    const identityList: Array<Identity> = [];
-                    windowList.forEach(winInfo => {
-                        identityList.push({uuid: winInfo.uuid, name: winInfo.windowName});
-                    });
-                    winGroups[index] = this.windowListFromIdentityList(identityList);
+        return this.wire.sendAction('get-application-groups', Object.assign({}, {
+            crossApp: true // cross app group supported
+        }, this.identity)).then(({ payload }) => {
+            payload.data.forEach((windowList: any[], index: number) => {
+                const identityList: Array<Identity> = [];
+                windowList.forEach(winInfo => {
+                    identityList.push({ uuid: winInfo.uuid, name: winInfo.windowName });
                 });
-
-                return winGroups;
+                winGroups[index] = this.windowListFromIdentityList(identityList);
             });
+
+            return winGroups;
+        });
     }
 
     /**
@@ -466,7 +467,8 @@ export class Application extends EmitterBase<ApplicationEvents> {
     * @tutorial Application.registerUser
     */
     public registerUser(userName: string, appName: string): Promise<void> {
-        return this.wire.sendAction('register-user', Object.assign({}, this.identity, {userName, appName})).then(() => undefined);
+        return this.wire.sendAction('register-user', Object.assign({}, { userName, appName }, this.identity))
+            .then(() => undefined);
     }
 
     /**
@@ -500,9 +502,9 @@ export class Application extends EmitterBase<ApplicationEvents> {
     }
     // tslint:disable-next-line:function-name
     private _run(): Promise<void> {
-        return this.wire.sendAction('run-application', Object.assign({}, this.identity, {
+        return this.wire.sendAction('run-application', Object.assign({}, {
             manifestUrl: this._manifestUrl
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -532,9 +534,9 @@ export class Application extends EmitterBase<ApplicationEvents> {
      * @tutorial Application.setTrayIcon
      */
     public setTrayIcon(iconUrl: string): Promise<void> {
-        return this.wire.sendAction('set-tray-icon', Object.assign({}, this.identity, {
+        return this.wire.sendAction('set-tray-icon', Object.assign({}, {
             enabledIcon: iconUrl
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -547,8 +549,8 @@ export class Application extends EmitterBase<ApplicationEvents> {
      * @tutorial Application.setShortcuts
      */
     public setShortcuts(config: ShortCutConfig): Promise<void> {
-        return this.wire.sendAction('set-shortcuts', Object.assign({}, this.identity, {data: config})
-               ).then(() => undefined);
+        return this.wire.sendAction('set-shortcuts', Object.assign({}, { data: config }, this.identity))
+            .then(() => undefined);
     }
 
     /**
@@ -559,7 +561,8 @@ export class Application extends EmitterBase<ApplicationEvents> {
      * @tutorial Application.setZoomLevel
      */
     public setZoomLevel(level: number): Promise<void> {
-        return this.wire.sendAction('set-application-zoom-level', Object.assign({}, this.identity, { level })).then(() => undefined);
+        return this.wire.sendAction('set-application-zoom-level', Object.assign({}, { level }, this.identity))
+            .then(() => undefined);
     }
 
     /**
@@ -569,7 +572,7 @@ export class Application extends EmitterBase<ApplicationEvents> {
      * @tutorial Application.setAppLogUsername
      */
     public async setAppLogUsername(username: string): Promise<void> {
-        await this.wire.sendAction('set-app-log-username', Object.assign({data: username}, this.identity));
+        await this.wire.sendAction('set-app-log-username', Object.assign({ data: username }, this.identity));
     }
 
     /**

--- a/src/api/window/window.ts
+++ b/src/api/window/window.ts
@@ -54,8 +54,8 @@ export default class _WindowModule extends Base {
      * @static
      */
     public create(options: WindowOption): Promise<_Window> {
-       const win = new _Window(this.wire, {uuid: this.me.uuid, name: options.name});
-       return win.createWindow(options);
+        const win = new _Window(this.wire, { uuid: this.me.uuid, name: options.name });
+        return win.createWindow(options);
     }
 
     /**
@@ -498,61 +498,61 @@ export class _Window extends WebContents<WindowEvents> {
      * @instance
      * @tutorial Window.EventEmitter
      */
-/**
-* Returns the zoom level of the window.
-* @function getZoomLevel
-* @memberOf Window
-* @instance
-* @return {Promise.<number>}
-* @tutorial Window.getZoomLevel
-*/
+    /**
+    * Returns the zoom level of the window.
+    * @function getZoomLevel
+    * @memberOf Window
+    * @instance
+    * @return {Promise.<number>}
+    * @tutorial Window.getZoomLevel
+    */
 
-/**
- * Sets the zoom level of the window.
- * @param { number } level The zoom level
- * @function setZoomLevel
- * @memberOf Window
- * @instance
- * @return {Promise.<void>}
- * @tutorial Window.setZoomLevel
- */
+    /**
+     * Sets the zoom level of the window.
+     * @param { number } level The zoom level
+     * @function setZoomLevel
+     * @memberOf Window
+     * @instance
+     * @return {Promise.<void>}
+     * @tutorial Window.setZoomLevel
+     */
 
-/**
- * Navigates the window to a specified URL. The url must contain the protocol prefix such as http:// or https://.
- * @param {string} url - The URL to navigate the window to.
- * @function navigate
- * @memberOf Window
- * @instance
- * @return {Promise.<void>}
- * @tutorial Window.navigate
- */
+    /**
+     * Navigates the window to a specified URL. The url must contain the protocol prefix such as http:// or https://.
+     * @param {string} url - The URL to navigate the window to.
+     * @function navigate
+     * @memberOf Window
+     * @instance
+     * @return {Promise.<void>}
+     * @tutorial Window.navigate
+     */
 
-/**
- * Navigates the window back one page.
- * @function navigateBack
- * @memberOf Window
- * @instance
- * @return {Promise.<void>}
- * @tutorial Window.navigateBack
- */
+    /**
+     * Navigates the window back one page.
+     * @function navigateBack
+     * @memberOf Window
+     * @instance
+     * @return {Promise.<void>}
+     * @tutorial Window.navigateBack
+     */
 
-/**
- * Navigates the window forward one page.
- * @function navigateForward
- * @memberOf Window
- * @instance
- * @return {Promise.<void>}
- * @tutorial Window.navigateForward
- */
+    /**
+     * Navigates the window forward one page.
+     * @function navigateForward
+     * @memberOf Window
+     * @instance
+     * @return {Promise.<void>}
+     * @tutorial Window.navigateForward
+     */
 
-/**
- * Stops any current navigation the window is performing.
- * @function stopNavigation
- * @memberOf Window
- * @instance
- * @return {Promise.<void>}
- * @tutorial Window.stopNavigation
- */
+    /**
+     * Stops any current navigation the window is performing.
+     * @function stopNavigation
+     * @memberOf Window
+     * @instance
+     * @return {Promise.<void>}
+     * @tutorial Window.stopNavigation
+     */
 
     // create a new window
     public createWindow(options: WindowOption): Promise<_Window> {
@@ -686,11 +686,11 @@ export class _Window extends WebContents<WindowEvents> {
      * @return {Promise.<void>}
      * @tutorial Window.animate
      */
-    public animate(transitions: Transition, options: TransitionOptions ): Promise<void> {
-        return this.wire.sendAction('animate-window', Object.assign({}, this.identity, {
-           transitions,
-           options
-        })).then(() => undefined);
+    public animate(transitions: Transition, options: TransitionOptions): Promise<void> {
+        return this.wire.sendAction('animate-window', Object.assign({}, {
+            transitions,
+            options
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -710,7 +710,7 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.close
     */
     public close(force: boolean = false): Promise<void> {
-        return this.wire.sendAction('close-window', Object.assign({}, this.identity, { force }))
+        return this.wire.sendAction('close-window', Object.assign({}, { force }, this.identity))
             .then(() => {
                 Object.setPrototypeOf(this, null);
                 return undefined;
@@ -798,12 +798,12 @@ export class _Window extends WebContents<WindowEvents> {
      * @return {Promise.<Array<_Window|ExternalWindow>>}
      * @tutorial Window.getGroup
      */
-    public getGroup(): Promise<Array<_Window|ExternalWindow>> {
-        return this.wire.sendAction('get-window-group', Object.assign({}, this.identity, {
+    public getGroup(): Promise<Array<_Window | ExternalWindow>> {
+        return this.wire.sendAction('get-window-group', Object.assign({}, {
             crossApp: true // cross app group supported
-        })).then(({ payload }) => {
+        }, this.identity)).then(({ payload }) => {
             // tslint:disable-next-line
-            let winGroup: Array<_Window|ExternalWindow> = [] as Array<_Window|ExternalWindow>;
+            let winGroup: Array<_Window | ExternalWindow> = [] as Array<_Window | ExternalWindow>;
 
             if (payload.data.length) {
                 winGroup = this.windowListFromNameList(payload.data);
@@ -817,7 +817,7 @@ export class _Window extends WebContents<WindowEvents> {
      * @return {Promise.<WindowInfo>}
      * @tutorial Window.getInfo
      */
-    public getInfo():  Promise<WindowInfo> {
+    public getInfo(): Promise<WindowInfo> {
         return this.wire.sendAction('get-window-info', this.identity).then(({ payload }) => payload.data);
     }
 
@@ -856,7 +856,7 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.getSnapshot
      */
     public async getSnapshot(area?: Area): Promise<string> {
-        const req = Object.assign({}, this.identity, { area });
+        const req = Object.assign({}, { area }, this.identity);
         const res = await this.wire.sendAction('get-window-snapshot', req);
         return res.payload.data;
     }
@@ -904,10 +904,10 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.joinGroup
      */
     public joinGroup(target: _Window | ExternalWindow): Promise<void> {
-        return this.wire.sendAction('join-window-group', Object.assign({}, this.identity, {
+        return this.wire.sendAction('join-window-group', Object.assign({}, {
             groupingUuid: target.identity.uuid,
             groupingWindowName: target.identity.name
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -916,9 +916,9 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.reload
      */
     public reload(ignoreCache: boolean = false): Promise<void> {
-        return this.wire.sendAction('reload-window', Object.assign({}, this.identity, {
+        return this.wire.sendAction('reload-window', Object.assign({}, {
             ignoreCache
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -946,10 +946,10 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.mergeGroups
      */
     public mergeGroups(target: _Window | ExternalWindow): Promise<void> {
-        return this.wire.sendAction('merge-window-groups', Object.assign({}, this.identity, {
+        return this.wire.sendAction('merge-window-groups', Object.assign({}, {
             groupingUuid: target.identity.uuid,
             groupingWindowName: target.identity.name
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -970,11 +970,11 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.moveBy
      */
     public moveBy(deltaLeft: number, deltaTop: number, options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
-        return this.wire.sendAction('move-window-by', Object.assign({}, this.identity, {
+        return this.wire.sendAction('move-window-by', Object.assign({}, {
             deltaLeft,
             deltaTop,
             options
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -986,11 +986,11 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.moveTo
      */
     public moveTo(left: number, top: number, options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
-        return this.wire.sendAction('move-window', Object.assign({}, this.identity, {
+        return this.wire.sendAction('move-window', Object.assign({}, {
             left,
             top,
             options
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -1006,12 +1006,12 @@ export class _Window extends WebContents<WindowEvents> {
      */
     public resizeBy(deltaWidth: number, deltaHeight: number, anchor: AnchorType,
         options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
-        return this.wire.sendAction('resize-window-by', Object.assign({}, this.identity, {
+        return this.wire.sendAction('resize-window-by', Object.assign({}, {
             deltaWidth: Math.floor(deltaWidth),
             deltaHeight: Math.floor(deltaHeight),
             anchor,
             options
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -1027,12 +1027,12 @@ export class _Window extends WebContents<WindowEvents> {
      */
     public resizeTo(width: number, height: number, anchor: AnchorType,
         options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
-        return this.wire.sendAction('resize-window', Object.assign({}, this.identity, {
+        return this.wire.sendAction('resize-window', Object.assign({}, {
             width: Math.floor(width),
             height: Math.floor(height),
             anchor,
             options
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -1061,7 +1061,7 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.setBounds
      */
     public setBounds(bounds: Bounds, options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
-        return this.wire.sendAction('set-window-bounds', Object.assign({}, this.identity, { ...bounds, options })).then(() => undefined);
+        return this.wire.sendAction('set-window-bounds', Object.assign({}, { ...bounds, options }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -1072,7 +1072,7 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.show
      */
     public show(force: boolean = false): Promise<void> {
-        return this.wire.sendAction('show-window', Object.assign({}, this.identity, { force })).then(() => undefined);
+        return this.wire.sendAction('show-window', Object.assign({}, { force }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -1089,12 +1089,12 @@ export class _Window extends WebContents<WindowEvents> {
      */
     public showAt(left: number, top: number, force: boolean = false,
         options: WindowMovementOptions = { moveIndependently: false }): Promise<void> {
-        return this.wire.sendAction('show-at-window', Object.assign({}, this.identity, {
+        return this.wire.sendAction('show-at-window', Object.assign({}, {
             force,
             left: Math.floor(left),
             top: Math.floor(top),
             options
-        })).then(() => undefined);
+        }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -1114,7 +1114,7 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.updateOptions
      */
     public updateOptions(options: any): Promise<void> {
-        return this.wire.sendAction('update-window-options', Object.assign({}, this.identity, { options })).then(() => undefined);
+        return this.wire.sendAction('update-window-options', Object.assign({}, { options }, this.identity)).then(() => undefined);
     }
 
     /**
@@ -1125,7 +1125,7 @@ export class _Window extends WebContents<WindowEvents> {
      * @tutorial Window.authenticate
      */
     public authenticate(userName: string, password: string): Promise<void> {
-        return this.wire.sendAction('window-authenticate', Object.assign({}, this.identity, { userName, password })).then(() => undefined);
+        return this.wire.sendAction('window-authenticate', Object.assign({}, { userName, password }, this.identity)).then(() => undefined);
     }
 
 }


### PR DESCRIPTION
This fixes a bug where the incorrect order of arguments in `Object.assign({}, ...)` would cause an override of `this.identity` if `name` or `uuid` are passed as options.