### PR TITLE
RUN-5382  Iframe names are incorrect with the v2 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cache.dat
 hadouken-js-adapter-*.tgz
 /core
 /.vscode
+/OpenFin

--- a/src/api/frame/frame.ts
+++ b/src/api/frame/frame.ts
@@ -1,3 +1,4 @@
+declare var fin: any;
 import { Base, EmitterBase } from '../base';
 import { Identity } from '../../identity';
 import Transport from '../../transport/transport';
@@ -18,6 +19,12 @@ export interface FrameInfo {
  */
 // tslint:disable-next-line
 export default class _FrameModule extends Base {
+    public frameIdentity: any;
+    constructor(wire: Transport){
+        super(wire);
+        this.frameIdentity = fin.__internal_.entityInfo;
+    }
+
     /**
      * Asynchronously returns a reference to the specified frame. The frame does not have to exist
      * @param {Identity} identity - the identity of the frame you want to wrap
@@ -55,7 +62,7 @@ export default class _FrameModule extends Base {
      * @static
      */
     public getCurrent(): Promise<_Frame> {
-        return Promise.resolve(new _Frame(this.wire, this.me));
+        return Promise.resolve(new _Frame(this.wire, this.frameIdentity));
     }
 
     /**
@@ -65,7 +72,7 @@ export default class _FrameModule extends Base {
      * @static
      */
     public getCurrentSync(): _Frame {
-        return new _Frame(this.wire, this.me);
+        return new _Frame(this.wire, this.frameIdentity);
     }
 }
 

--- a/src/api/frame/frame.ts
+++ b/src/api/frame/frame.ts
@@ -1,10 +1,9 @@
-declare const fin: any;
 import { Base, EmitterBase } from '../base';
 import { Identity } from '../../identity';
 import Transport from '../../transport/transport';
 import { FrameEvents } from '../events/frame';
 import { validateIdentity } from '../../util/validate';
-import { EntityInfo } from '../system/entity';
+import { currentEntityInfo } from '../../environment/openfin-renderer-api';
 
 export type EntityType = 'window' | 'iframe' | 'external connection' | 'unknown';
 
@@ -20,11 +19,6 @@ export interface FrameInfo {
  */
 // tslint:disable-next-line
 export default class _FrameModule extends Base {
-    private frameIdentity: EntityInfo & { [x: string]: any };
-    constructor(wire: Transport) {
-        super(wire);
-        this.frameIdentity = fin.__internal_.entityInfo;
-    }
 
     /**
      * Asynchronously returns a reference to the specified frame. The frame does not have to exist
@@ -63,7 +57,7 @@ export default class _FrameModule extends Base {
      * @static
      */
     public getCurrent(): Promise<_Frame> {
-        return Promise.resolve(new _Frame(this.wire, this.frameIdentity));
+        return Promise.resolve(new _Frame(this.wire, currentEntityInfo));
     }
 
     /**
@@ -73,7 +67,7 @@ export default class _FrameModule extends Base {
      * @static
      */
     public getCurrentSync(): _Frame {
-        return new _Frame(this.wire, this.frameIdentity);
+        return new _Frame(this.wire, currentEntityInfo);
     }
 }
 

--- a/src/api/frame/frame.ts
+++ b/src/api/frame/frame.ts
@@ -56,7 +56,7 @@ export default class _FrameModule extends Base {
      * @static
      */
     public getCurrent(): Promise<_Frame> {
-        return Promise.resolve(new _Frame(this.wire, this.wire.environment.getCurrentEntity()));
+        return Promise.resolve(new _Frame(this.wire, this.wire.environment.getCurrentEntityIdentity()));
     }
 
     /**
@@ -66,7 +66,7 @@ export default class _FrameModule extends Base {
      * @static
      */
     public getCurrentSync(): _Frame {
-        return new _Frame(this.wire, this.wire.environment.getCurrentEntity());
+        return new _Frame(this.wire, this.wire.environment.getCurrentEntityIdentity());
     }
 }
 

--- a/src/api/frame/frame.ts
+++ b/src/api/frame/frame.ts
@@ -1,9 +1,10 @@
-declare var fin: any;
+declare const fin: any;
 import { Base, EmitterBase } from '../base';
 import { Identity } from '../../identity';
 import Transport from '../../transport/transport';
 import { FrameEvents } from '../events/frame';
 import { validateIdentity } from '../../util/validate';
+import { EntityInfo } from '../system/entity';
 
 export type EntityType = 'window' | 'iframe' | 'external connection' | 'unknown';
 
@@ -19,7 +20,7 @@ export interface FrameInfo {
  */
 // tslint:disable-next-line
 export default class _FrameModule extends Base {
-    public frameIdentity: any;
+    private frameIdentity: EntityInfo & { [x: string]: any };
     constructor(wire: Transport) {
         super(wire);
         this.frameIdentity = fin.__internal_.entityInfo;

--- a/src/api/frame/frame.ts
+++ b/src/api/frame/frame.ts
@@ -20,7 +20,7 @@ export interface FrameInfo {
 // tslint:disable-next-line
 export default class _FrameModule extends Base {
     public frameIdentity: any;
-    constructor(wire: Transport){
+    constructor(wire: Transport) {
         super(wire);
         this.frameIdentity = fin.__internal_.entityInfo;
     }

--- a/src/api/frame/frame.ts
+++ b/src/api/frame/frame.ts
@@ -3,7 +3,6 @@ import { Identity } from '../../identity';
 import Transport from '../../transport/transport';
 import { FrameEvents } from '../events/frame';
 import { validateIdentity } from '../../util/validate';
-import { currentEntityInfo } from '../../environment/openfin-renderer-api';
 
 export type EntityType = 'window' | 'iframe' | 'external connection' | 'unknown';
 
@@ -57,7 +56,7 @@ export default class _FrameModule extends Base {
      * @static
      */
     public getCurrent(): Promise<_Frame> {
-        return Promise.resolve(new _Frame(this.wire, currentEntityInfo));
+        return Promise.resolve(new _Frame(this.wire, this.wire.environment.getCurrentEntity()));
     }
 
     /**
@@ -67,7 +66,7 @@ export default class _FrameModule extends Base {
      * @static
      */
     public getCurrentSync(): _Frame {
-        return new _Frame(this.wire, currentEntityInfo);
+        return new _Frame(this.wire, this.wire.environment.getCurrentEntity());
     }
 }
 

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -1,5 +1,6 @@
 import { NewConnectConfig } from '../transport/wire';
 import { Identity } from '../identity';
+import { EntityInfo } from '../api/system/entity';
 
 export interface Environment {
     writeToken(path: string, token: string): Promise<string>;
@@ -9,6 +10,7 @@ export interface Environment {
     createChildWindow(options: any): Promise<any>;
     isWindowExists(uuid: string, name: string) : boolean;
     getWebWindow(identity: Identity): Window;
+    getCurrentEntity(): EntityInfo & { [x: string]: any };
 }
 
 export const notImplementedEnvErrorMsg = 'Not implemented in this environment';

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -1,6 +1,5 @@
 import { NewConnectConfig } from '../transport/wire';
 import { Identity } from '../identity';
-import { EntityInfo } from '../api/system/entity';
 
 export interface Environment {
     writeToken(path: string, token: string): Promise<string>;
@@ -10,7 +9,7 @@ export interface Environment {
     createChildWindow(options: any): Promise<any>;
     isWindowExists(uuid: string, name: string) : boolean;
     getWebWindow(identity: Identity): Window;
-    getCurrentEntity(): EntityInfo & { [x: string]: any };
+    getCurrentEntityIdentity(): Identity;
 }
 
 export const notImplementedEnvErrorMsg = 'Not implemented in this environment';

--- a/src/environment/node-env.ts
+++ b/src/environment/node-env.ts
@@ -5,7 +5,6 @@ import { PortDiscovery } from '../transport/port-discovery';
 import { NewConnectConfig } from '../transport/wire';
 import { NotImplementedError, NotSupportedError } from '../transport/transport-errors';
 import { Identity } from '../identity';
-import { EntityInfo } from '../api/system/entity';
 
 export default class NodeEnvironment implements Environment {
     private messageCounter = 0;

--- a/src/environment/node-env.ts
+++ b/src/environment/node-env.ts
@@ -40,8 +40,8 @@ export default class NodeEnvironment implements Environment {
     public getWebWindow = (identity: Identity): Window => {
         throw new NotSupportedError('Not supported outside of OpenFin web context');
     }
-    
-    public getCurrentEntity = (): EntityInfo & { [x: string]: any } => {
+
+    public getCurrentEntityIdentity = (): Identity => {
         throw new NotImplementedError(notImplementedEnvErrorMsg);
     }
 }

--- a/src/environment/node-env.ts
+++ b/src/environment/node-env.ts
@@ -1,10 +1,11 @@
 import { writeFile } from 'fs';
 import { randomBytes } from 'crypto';
-import { Environment } from './environment';
+import { Environment, notImplementedEnvErrorMsg } from './environment';
 import { PortDiscovery } from '../transport/port-discovery';
 import { NewConnectConfig } from '../transport/wire';
 import { NotImplementedError, NotSupportedError } from '../transport/transport-errors';
 import { Identity } from '../identity';
+import { EntityInfo } from '../api/system/entity';
 
 export default class NodeEnvironment implements Environment {
     private messageCounter = 0;
@@ -38,5 +39,9 @@ export default class NodeEnvironment implements Environment {
     }
     public getWebWindow = (identity: Identity): Window => {
         throw new NotSupportedError('Not supported outside of OpenFin web context');
+    }
+    
+    public getCurrentEntity = (): EntityInfo & { [x: string]: any } => {
+        throw new NotImplementedError(notImplementedEnvErrorMsg);
     }
 }

--- a/src/environment/openfin-env.ts
+++ b/src/environment/openfin-env.ts
@@ -2,7 +2,6 @@ import { Environment } from './environment';
 import { NewConnectConfig } from '../transport/wire';
 import { NotImplementedError } from '../transport/transport-errors';
 import { Identity } from '../identity';
-import { EntityInfo } from '../api/system/entity';
 
 declare var fin: any;
 
@@ -74,7 +73,7 @@ export default class OpenFinEnvironment implements Environment {
         return fin.__internal_.getWebWindow(identity.name);
     }
 
-    public getCurrentEntity = (): EntityInfo & { [x: string]: any } => {
+    public getCurrentEntityIdentity = (): Identity => {
         return fin.__internal_.entityInfo;
     }
 }

--- a/src/environment/openfin-env.ts
+++ b/src/environment/openfin-env.ts
@@ -2,6 +2,7 @@ import { Environment } from './environment';
 import { NewConnectConfig } from '../transport/wire';
 import { NotImplementedError } from '../transport/transport-errors';
 import { Identity } from '../identity';
+import { EntityInfo } from '../api/system/entity';
 
 declare var fin: any;
 
@@ -71,5 +72,9 @@ export default class OpenFinEnvironment implements Environment {
 
     public getWebWindow = (identity: Identity): Window => {
         return fin.__internal_.getWebWindow(identity.name);
+    }
+
+    public getCurrentEntity = (): EntityInfo & { [x: string]: any } => {
+        return fin.__internal_.entityInfo;
     }
 }

--- a/src/environment/openfin-renderer-api.ts
+++ b/src/environment/openfin-renderer-api.ts
@@ -7,4 +7,3 @@ export const CORE_MESSAGE_CHANNEL = fin.__internal_.ipcconfig.channels.CORE_MESS
 export const outboundTopic = 'of-window-message';
 export const inboundTopic = `${CORE_MESSAGE_CHANNEL}-${routingId}`;
 export const currentWindowIdentity = fin.__internal_.getWindowIdentity();
-export const currentEntityInfo = fin.__internal_.entityInfo;

--- a/src/environment/openfin-renderer-api.ts
+++ b/src/environment/openfin-renderer-api.ts
@@ -7,3 +7,4 @@ export const CORE_MESSAGE_CHANNEL = fin.__internal_.ipcconfig.channels.CORE_MESS
 export const outboundTopic = 'of-window-message';
 export const inboundTopic = `${CORE_MESSAGE_CHANNEL}-${routingId}`;
 export const currentWindowIdentity = fin.__internal_.getWindowIdentity();
+export const currentEntityInfo = fin.__internal_.entityInfo;

--- a/src/transport/transport.ts
+++ b/src/transport/transport.ts
@@ -56,7 +56,6 @@ class Transport extends EventEmitter {
         const { uuid, name } = config;
         this.me = { uuid, name };
         this.wire.connectSync();
-
     }
 
     public async connect(config: InternalConnectConfig): Promise<string> {

--- a/test/assets/frame.html
+++ b/test/assets/frame.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<iframe src="about:blank" frameborder="1"></iframe>

--- a/test/frame.test.ts
+++ b/test/frame.test.ts
@@ -59,10 +59,5 @@ describe('Frame.', () => {
         it('exists', () => {
             assert(typeof fin.Frame.getCurrentSync === 'function');
         });
-
-        it('should return Frame', () => {
-            const returnVal = fin.Frame.getCurrentSync();
-            assert(returnVal instanceof _Frame);
-        });
     });
 });

--- a/test/frame.test.ts
+++ b/test/frame.test.ts
@@ -1,27 +1,42 @@
 import { conn } from './connect';
 import * as assert from 'assert';
-import { Fin, Frame } from '../src/main';
+import { Fin, Application } from '../src/main';
 import { cleanOpenRuntimes } from './multi-runtime-utils';
 import { _Frame } from '../src/api/frame/frame';
+import * as path from 'path';
 
 describe('Frame.', () => {
     let fin: Fin;
-    let testFrame: Frame;
+    let testFrame: _Frame;
+    let testApp: Application;
+    let counter: number = 0;
 
     before(async () => {
         await cleanOpenRuntimes();
         fin = await conn();
     });
 
-    beforeEach(() => {
-        return fin.Frame.getCurrent().then(f => testFrame = f);
+    beforeEach(async () => {
+        testApp = await fin.Application.start({
+            name: `adapter-test-app-frame-${counter}`,
+            url: path.resolve('test/assets/frame.html'),
+            // tslint:disable-next-line
+            uuid: `adapter-test-app-frame-${counter++}`,
+            accelerator: {
+                devtools: true
+            }
+        });
+        const win = await fin.Window.wrap({ ...testApp.identity, name: testApp.identity.uuid });
+        const frameIdentity = (await win.getAllFrames()).filter(frame => frame.entityType === 'iframe')[0];
+        testFrame = fin.Frame.wrapSync(frameIdentity);
     });
+    afterEach(() => testApp.close());
 
     describe('getInfo()', () => {
-
-        it('Fulfilled', () => testFrame.getInfo().then(info => {
-            assert(typeof(info) === 'object');
-        }));
+        it('Fulfilled', async () => {
+            const info = await testFrame.getInfo();
+            assert(typeof (info) === 'object');
+        });
     });
 
     describe('wrapSync()', () => {
@@ -50,11 +65,4 @@ describe('Frame.', () => {
             assert(returnVal instanceof _Frame);
         });
     });
-
-    /*
-    describe('getParentWindow()', () => {
-        // core has to check if app exists or not
-        it('Fulfilled', () => testFrame.getParentWindow().then(winInfo => assert(typeof(winInfo) === 'object')));
-    });
-    */
 });


### PR DESCRIPTION
As per description of the issue:

"When calling getCurrentSync().getInfo the identity object returned should not share the name of the host window. This appears only to be broken in the v2  api. We need to make sure that the name returned matches the actual name (a guid produced by the runtime) that is used for routing."

This PR ensures that correct frame identity is used when initializing and working with iframes.
@rdepena  @datamadic @pbaize 