### PR TITLE
RUN-5456 There’s no way of programmatically telling if a window has enabled or disabled user movement

### DIFF
--- a/tutorials/Window.getInfo.md
+++ b/tutorials/Window.getInfo.md
@@ -5,6 +5,7 @@ Gets an information object for the window.
 {
     "canNavigateBack":false,
     "canNavigateForward":false,
+    "isUserMovementEnabled":true,
     "preloadScripts":[],
     "title":"JSDoc: Tutorial: Window.getInfo",
     "url":"https://cdn.openfin.co/docs/javascript/stable/tutorial-Window.getInfo.html"


### PR DESCRIPTION
#### Description of Change
The PR documents the proposed `isUserMovementEnabled` field in `window.getInfo()` for users to be able to tell programmatically whether user movement is enabled

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] relevant documentation is changed or added
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers

Test: https://testing-dashboard.openfin.co/#/app/tests/5d48843a394bc65e455b9a6e/edit

#### Release Notes

Notes: Added `isUserMovementEnabled` property to `window.getInfo()` that allows to programmatically discover whether user movement is enabled