### PR TITLE
RUN-5491 incorrectly set security realm

### DIFF
--- a/test/uuid-enforcement.test.ts
+++ b/test/uuid-enforcement.test.ts
@@ -15,7 +15,10 @@ const newManifestPath = (uuid: string) => path.resolve(`test/uuid-enforcement-ap
 const createManifest = (uuid: string, securityRealm = `uuid-enforcement-realm-${realmCount += 1}`) => {
     const manifest = {
         startup_app: { uuid, name: uuid },
-        runtime: { version: testVersion, securityRealm }
+        runtime: {
+            version: testVersion,
+            arguments: '--enable-mesh --security-realm=' + securityRealm
+        }
     };
     manifestPath = newManifestPath(uuid);
     fs.writeFileSync(manifestPath, JSON.stringify(manifest));

--- a/test/uuid-enforcement.test.ts
+++ b/test/uuid-enforcement.test.ts
@@ -34,7 +34,10 @@ const newUuid = () => `duplicatedUuid${uuidCount += 1}`;
 let runningApps: Application[] = [];
 
 async function cleanupRunningApps() {
-    await Promise.all(runningApps.map(app => app.quit()));
+    const asyncQuit = async (app: Application) => {
+        return await app.quit();
+    };
+    runningApps.map(app => asyncQuit(app));
     runningApps = [];
     return;
 }


### PR DESCRIPTION
This PR is to fix incorrectly set security realm issue in uuid enforcement test. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
