### PR TITLE
[RUN-5434]/[RUN-5435] Add startManyManifests to fin.Application

### DIFF
--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -176,6 +176,17 @@ export default class ApplicationModule extends Base {
     }
 
     /**
+     * Runs an array of applications from manifest.
+     * @param { applications } Array<Identity & { manifestUrl: string }>
+     * @return {Promise.<void>}
+     * @static
+     * @experimental
+     */
+    public startManyManifests(applications: Array<Identity & { manifestUrl: string }>): Promise<void> {
+        return this.wire.sendAction('run-applications', { applications }).then(() => undefined);
+    }
+
+    /**
      * Asynchronously returns an Application object that represents the current application
      * @return {Promise.<Application>}
      * @tutorial Application.getCurrent


### PR DESCRIPTION
#### Description of Change

Adds the `fin.Application.startManyManifests` function to the API. This function takes an array of applications (and their manifests), and sends that array of applications to the RVM for it to run. This batching is meant to avoid issues with sending a large amount of `run-application` messages to the RVM. 

Paired with the following PRs:
https://github.com/HadoukenIO/core/pull/907


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [(Will wait until all PRs are merged in, so I can point at a version)] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [N/A] relevant documentation is changed or added
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [N/A] PR release notes describe the change in a way relevant to app-developers
- [X] PR has assigned reviewers


#### Release Notes

N/A, not public.

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
