### PR TITLE
RUN-5584 - Multi-runtime onDisconnection from ChannelProvider

### DIFF
--- a/src/api/interappbus/channel/client.ts
+++ b/src/api/interappbus/channel/client.ts
@@ -20,8 +20,8 @@ export class ChannelClient extends ChannelBase {
     }
 
     public async disconnect(): Promise<void> {
-        const { channelName } = this.providerIdentity;
-        await this.sendRaw('disconnect-from-channel', { channelName });
+        const { channelName, uuid, name } = this.providerIdentity;
+        await this.sendRaw('disconnect-from-channel', { channelName, uuid, name });
         const { channelId } = this.providerIdentity;
         this.removeChannel(channelId);
     }


### PR DESCRIPTION
#### Description of Change
Channel onDisconnection from the provider (on client disconnection) was not working multi-runtime. This PR makes it work.  The services team needs this for notifications. 

Goes with [this Core PR](https://github.com/HadoukenIO/core/pull/924)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [added](https://testing-dashboard.openfin.co/#/app/tests/5d7129035cca4e5a7198d3b3/edit)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] Link to new tests [added](https://testing-dashboard.openfin.co/#/app/tests/5d7129035cca4e5a7198d3b3/edit)
- [x] PR has assigned reviewers

#### Release Notes

Notes: Fixed bug where channel onDisconnection from the provider was not working across runtimes.
