### PR TITLE
RVM-976 StartFromManifest rvmLaunchOptions

### DIFF
--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -221,6 +221,7 @@ export default class ApplicationModule extends Base {
     /**
      * Retrieves application's manifest and returns a running instance of the application.
      * @param {string} manifestUrl - The URL of app's manifest.
+     * @param { rvmLaunchOpts} [opts] - Parameters that the RVM will use.
      * @return {Promise.<Application>}
      * @tutorial Application.startFromManifest
      * @static

--- a/src/api/application/application.ts
+++ b/src/api/application/application.ts
@@ -50,6 +50,11 @@ export interface ManifestInfo {
     manifestUrl: string;
 }
 
+export interface RvmLaunchOptions {
+    noUi?: boolean;
+    userAppConfigArgs?: object;
+}
+
 /**
  * @typedef {object} ApplicationOption
  * @summary Application creation options.
@@ -220,10 +225,10 @@ export default class ApplicationModule extends Base {
      * @tutorial Application.startFromManifest
      * @static
      */
-    public async startFromManifest(manifestUrl: string): Promise<Application> {
+    public async startFromManifest(manifestUrl: string, opts?: RvmLaunchOptions): Promise<Application> {
         const app = await this._createFromManifest(manifestUrl);
         //@ts-ignore using private method without warning.
-        await app._run();
+        await app._run(opts);
         return app;
     }
     public createFromManifest(manifestUrl: string): Promise<Application> {
@@ -518,10 +523,12 @@ export class Application extends EmitterBase<ApplicationEvents> {
         console.warn('Deprecation Warning: Application.run is deprecated Please use fin.Application.start');
         return this._run();
     }
+
     // tslint:disable-next-line:function-name
-    private _run(): Promise<void> {
+    private _run(opts: RvmLaunchOptions = {}): Promise<void> {
         return this.wire.sendAction('run-application', Object.assign({}, {
-            manifestUrl: this._manifestUrl
+            manifestUrl: this._manifestUrl,
+            opts
         }, this.identity)).then(() => undefined);
     }
 


### PR DESCRIPTION
#### Description of Change
Added rvmLaunchOptions to startFromManifest(), which contains to parameters.

noUi - a way to tell the rvm to launch an app with the no-ui option.
userAppConfigArgs - a map of deep linking params that can be appended to the manifest url.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] Integration tests added in this repo and in the [test dashboard](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is changed or added
- [ ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
